### PR TITLE
Harden container lifecycle and daemon recovery for concurrent/crash safety

### DIFF
--- a/pkg/cmd/clear.go
+++ b/pkg/cmd/clear.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ahmetozer/sandal/pkg/container/config/wrapper"
 	"github.com/ahmetozer/sandal/pkg/container/host"
 	"github.com/ahmetozer/sandal/pkg/container/host/clean"
+	"github.com/ahmetozer/sandal/pkg/container/namelock"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
 	"github.com/ahmetozer/sandal/pkg/env"
@@ -89,11 +90,8 @@ func Clear(args []string) error {
 				continue
 			}
 		}
-		pid := c.ContPid
-		if pid == 0 && c.VM != "" {
-			pid = c.HostPid
-		}
-		isRunning, err := crt.IsPidRunning(pid)
+		pid, wantStart := c.MonitorPidIdentity()
+		isRunning, err := crt.IsPidRunningAs(pid, wantStart)
 		if err != nil {
 			slog.Error("unable to get container status", "container", c.Name, "err", err)
 		}
@@ -201,7 +199,24 @@ func Clear(args []string) error {
 			if !toRemove[c.Name] {
 				continue
 			}
+			// Lock per name and re-verify it isn't running under the lock, so a
+			// bulk clear can't tear down a container the daemon (re)started
+			// since the snapshot was taken (audit L5).
+			release, err := namelock.Acquire(c.Name, namelock.DefaultTimeout)
+			if err != nil {
+				slog.Error("clear: acquire lifecycle lock", "container", c.Name, "err", err)
+				continue
+			}
+			if latest, gerr := controller.GetContainer(c.Name); gerr == nil {
+				pid, wantStart := latest.MonitorPidIdentity()
+				if alive, _ := crt.IsPidRunningAs(pid, wantStart); alive {
+					slog.Warn("clear: skipping now-running container", "container", c.Name)
+					release()
+					continue
+				}
+			}
 			host.DeRunContainer(c)
+			release()
 		}
 	}
 

--- a/pkg/cmd/kill.go
+++ b/pkg/cmd/kill.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/ahmetozer/sandal/pkg/container/namelock"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
 	"github.com/ahmetozer/sandal/pkg/sandal"
@@ -63,8 +64,18 @@ func Kill(args []string) error {
 
 	var lastErr error
 	for _, name := range names {
+		// Hold the per-name lifecycle lock so a kill can't race a concurrent
+		// daemon recovery / run of the same name (which would kill the wrong
+		// instance or leave one detached).
+		release, err := namelock.Acquire(name, namelock.DefaultTimeout)
+		if err != nil {
+			fmt.Printf("kill %s: %s\n", name, err)
+			lastErr = err
+			continue
+		}
 		c, err := controller.GetContainer(name)
 		if err != nil {
+			release()
 			fmt.Printf("kill %s: %s\n", name, err)
 			lastErr = err
 			continue
@@ -73,6 +84,7 @@ func Kill(args []string) error {
 			fmt.Printf("kill %s: %s\n", name, err)
 			lastErr = err
 		}
+		release()
 	}
 	return lastErr
 }

--- a/pkg/cmd/rerun.go
+++ b/pkg/cmd/rerun.go
@@ -7,8 +7,9 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/ahmetozer/sandal/pkg/container/host"
+	"github.com/ahmetozer/sandal/pkg/container/namelock"
 	"github.com/ahmetozer/sandal/pkg/controller"
+	"github.com/ahmetozer/sandal/pkg/sandal"
 )
 
 func Rerun(args []string) error {
@@ -25,7 +26,15 @@ func Rerun(args []string) error {
 		return err
 	}
 
-	err = host.Kill(c, 9, 5)
+	// Hold the per-name lifecycle lock across the kill so it can't race a
+	// concurrent run/recover, then release before Run (which re-acquires the
+	// same lock). sandal.Kill routes VM containers to their HostPid.
+	release, err := namelock.Acquire(c.Name, namelock.DefaultTimeout)
+	if err != nil {
+		return fmt.Errorf("acquire lifecycle lock: %w", err)
+	}
+	err = sandal.Kill(c, 9, 5)
+	release()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/rm.go
+++ b/pkg/cmd/rm.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/ahmetozer/sandal/pkg/container/host"
+	"github.com/ahmetozer/sandal/pkg/container/namelock"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
 )
@@ -36,11 +37,8 @@ func Rm(args []string) error {
 
 	if all {
 		for _, c := range conts {
-			pid := c.ContPid
-			if pid == 0 && c.VM != "" {
-				pid = c.HostPid
-			}
-			isRunning, _ := crt.IsPidRunning(pid)
+			pid, wantStart := c.MonitorPidIdentity()
+			isRunning, _ := crt.IsPidRunningAs(pid, wantStart)
 			if !isRunning {
 				names = append(names, c.Name)
 			}
@@ -52,30 +50,48 @@ func Rm(args []string) error {
 	}
 
 	var errs []error
-RequestedContainers:
 	for _, name := range names {
+		exists := false
 		for _, c := range conts {
 			if c.Name == name {
-				pid := c.ContPid
-				if pid == 0 && c.VM != "" {
-					pid = c.HostPid
-				}
-				isRunning, err := crt.IsPidRunning(pid)
-
-				if err != nil {
-					errs = append(errs, fmt.Errorf("unable to check existence of '%s' container: %v", c.Name, err))
-				}
-				if isRunning {
-					errs = append(errs, fmt.Errorf("container %s is running, please stop it first", c.Name))
-					continue RequestedContainers
-				}
-
-				c.Remove = true
-				host.DeRunContainer(c)
-				continue RequestedContainers
+				exists = true
+				break
 			}
 		}
-		errs = append(errs, fmt.Errorf("container %s is not found", name))
+		if !exists {
+			errs = append(errs, fmt.Errorf("container %s is not found", name))
+			continue
+		}
+
+		// Hold the per-name lifecycle lock and re-read the latest config under
+		// it, so we never tear down (and delete the config/rootfs of) a
+		// container the daemon just (re)started between our snapshot and now,
+		// which would leave that fresh instance detached (audit L5).
+		release, err := namelock.Acquire(name, namelock.DefaultTimeout)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("rm %s: acquire lifecycle lock: %w", name, err))
+			continue
+		}
+
+		c, err := controller.GetContainer(name)
+		if err != nil {
+			release()
+			errs = append(errs, fmt.Errorf("container %s is not found", name))
+			continue
+		}
+
+		pid, wantStart := c.MonitorPidIdentity()
+		if isRunning, rerr := crt.IsPidRunningAs(pid, wantStart); rerr != nil {
+			errs = append(errs, fmt.Errorf("unable to check existence of '%s' container: %v", name, rerr))
+		} else if isRunning {
+			release()
+			errs = append(errs, fmt.Errorf("container %s is running, please stop it first", name))
+			continue
+		}
+
+		c.Remove = true
+		host.DeRunContainer(c)
+		release()
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)

--- a/pkg/cmd/stop.go
+++ b/pkg/cmd/stop.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/ahmetozer/sandal/pkg/container/host"
+	"github.com/ahmetozer/sandal/pkg/container/namelock"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
 )
@@ -62,6 +63,13 @@ func Stop(args []string) error {
 }
 
 func stopContainer(name string, signal, timeout int) error {
+	// Serialize with run/recover/kill/rm for this name.
+	release, err := namelock.Acquire(name, namelock.DefaultTimeout)
+	if err != nil {
+		return fmt.Errorf("acquire lifecycle lock: %w", err)
+	}
+	defer release()
+
 	cont, err := controller.GetContainer(name)
 	if err != nil {
 		return err

--- a/pkg/container/config/definitions.go
+++ b/pkg/container/config/definitions.go
@@ -23,6 +23,16 @@ type Config struct {
 	Created int64
 	HostPid int
 	ContPid int
+
+	// HostPidStart / ContPidStart are the kernel start-times
+	// (/proc/<pid>/stat field 22) of HostPid / ContPid, captured right after
+	// the process is spawned. Paired with the pid they form an identity that
+	// survives a daemon restart and defeats PID reuse: a recycled pid has a
+	// different start-time, so liveness/kill checks won't act on an unrelated
+	// process. 0 means "unknown" — checks degrade to plain liveness.
+	HostPidStart uint64
+	ContPidStart uint64
+
 	TmpSize       uint
 	ChangeDirSize string // Change dir disk image size (e.g. "128m", "1g", default "128m")
 	ChangeDirType string // "auto", "folder", "image"
@@ -81,6 +91,18 @@ var (
 	TypeInt    int
 	TypeUint   uint
 )
+
+// MonitorPidIdentity returns the pid to watch for liveness and its expected
+// start-time. VM containers are tracked by HostPid (the KVM process; their
+// host-side ContPid is never set); native containers by ContPid. Pair the
+// returned pid with the start-time via runtime.IsPidRunningAs so a recycled pid
+// is not mistaken for the container.
+func (c *Config) MonitorPidIdentity() (pid int, startTime uint64) {
+	if c.VM != "" {
+		return c.HostPid, c.HostPidStart
+	}
+	return c.ContPid, c.ContPidStart
+}
 
 func NewContainer() Config {
 	Config := Config{}

--- a/pkg/container/config/tools.go
+++ b/pkg/container/config/tools.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"path"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/ahmetozer/sandal/pkg/env"
@@ -41,4 +42,20 @@ func (c *Config) ConfigFileLoc() string {
 
 func ConfigFileLoc(name string) string {
 	return path.Join(env.BaseStateDir, name+".json")
+}
+
+// NameFromConfigFile is the inverse of ConfigFileLoc for a state file's base
+// name: "my.app.json" -> ("my.app", true). It strips the ".json" suffix rather
+// than splitting on ".", so names containing dots (which ValidateName permits)
+// survive. Returns ok=false when base is not a ".json" file or the decoded name
+// is not a valid container name.
+func NameFromConfigFile(base string) (string, bool) {
+	name, ok := strings.CutSuffix(base, ".json")
+	if !ok {
+		return "", false
+	}
+	if ValidateName(name) != nil {
+		return "", false
+	}
+	return name, true
 }

--- a/pkg/container/config/tools_test.go
+++ b/pkg/container/config/tools_test.go
@@ -1,0 +1,43 @@
+package config
+
+import "testing"
+
+// NameFromConfigFile is the inverse of ConfigFileLoc. It must strip the
+// ".json" suffix (not split on every "."), because ValidateName allows dots
+// in names. The daemon previously split on "." and required exactly two
+// parts, which silently dropped every dotted-name state file — breaking
+// removal and resurrecting deleted containers (audit L6).
+func TestNameFromConfigFile(t *testing.T) {
+	cases := []struct {
+		base string
+		want string
+		ok   bool
+	}{
+		{"x.json", "x", true},
+		{"my.app.json", "my.app", true},
+		{"a.b.c.json", "a.b.c", true},
+		{"web-1_v2.json", "web-1_v2", true},
+		{"noext", "", false},
+		{"foo.txt", "", false},
+		{".json", "", false},   // empty name
+		{"..json", "", false},  // ValidateName rejects leading "."
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := NameFromConfigFile(tc.base)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("NameFromConfigFile(%q) = (%q,%v), want (%q,%v)", tc.base, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// Round-trip: the name encoded by ConfigFileLoc must be recoverable.
+func TestNameFromConfigFileRoundTrip(t *testing.T) {
+	for _, name := range []string{"x", "my.app", "a.b.c", "web-1_v2"} {
+		base := name + ".json" // ConfigFileLoc joins BaseStateDir + name + ".json"
+		got, ok := NameFromConfigFile(base)
+		if !ok || got != name {
+			t.Errorf("round-trip %q: got (%q,%v)", name, got, ok)
+		}
+	}
+}

--- a/pkg/container/diskimage/mount.go
+++ b/pkg/container/diskimage/mount.go
@@ -39,15 +39,12 @@ func Mount(path string) (ImmutableImage, error) {
 		return image, err
 	}
 
-	image.LoopConfig, err = loopdev.FindFreeLoopDevice()
-	if err != nil {
-		return image, fmt.Errorf("cannot find free loop: %s", err)
-	}
-
+	// Resolve the desired geometry BEFORE allocating a loop, so we can look for
+	// an existing mount to reuse. parseImagePath sets LoopConfig.Info.Offset for
+	// partitioned images; squashfs is whole-file (offset 0).
 	switch image.Type {
 	case ImmutableImageTypeImgMBR, ImmutableImageTypeImgGPT:
-		err = image.parseImagePath()
-		if err != nil {
+		if err = image.parseImagePath(); err != nil {
 			return image, err
 		}
 	case ImmutableImageTypeSquashfs:
@@ -55,6 +52,31 @@ func Mount(path string) (ImmutableImage, error) {
 	default:
 		return image, fmt.Errorf("an unknown image type is chosen by the detect function")
 	}
+	var wantOffset uint64
+	if image.LoopConfig.Info != nil {
+		wantOffset = image.LoopConfig.Info.Offset
+	}
+
+	// Reuse: if this exact file+offset is already loop-mounted, point at the
+	// existing mount instead of allocating a new loop and mounting again. This
+	// makes mounting idempotent (no accumulation on restart/failed-recovery) and
+	// shares identical read-only base images across containers.
+	if mp, no, ok := findMountedImmutable(image.File, wantOffset, 0); ok {
+		image.LoopConfig = loopdev.Config{No: no, Path: loopdev.DevicePath(no), Info: image.LoopConfig.Info}
+		image.MountDir = mp
+		slog.Debug("diskimage", slog.String("func", "mount"), slog.String("action", "reuse"),
+			slog.String("file", image.File), slog.Int("loop", no), slog.String("mountDir", mp))
+		return image, nil
+	}
+
+	// Miss: allocate a fresh loop. FindFreeLoopDevice returns a new Config, so
+	// re-apply the partition offset (Info) computed above.
+	savedInfo := image.LoopConfig.Info
+	image.LoopConfig, err = loopdev.FindFreeLoopDevice()
+	if err != nil {
+		return image, fmt.Errorf("cannot find free loop: %s", err)
+	}
+	image.LoopConfig.Info = savedInfo
 
 	err = image.unixMount()
 	slog.Debug("diskimage", slog.String("func", "mount"), slog.Any("err", err))
@@ -75,11 +97,13 @@ func (c *ImmutableImage) unixMount() (err error) {
 
 	err = os.MkdirAll(c.MountDir, 0o0755)
 	if err != nil {
+		c.LoopConfig.Detach() // don't leak the loop we just attached
 		return fmt.Errorf("creating rootfs directory: %s", err)
 	}
 
 	fsType, err := detectfs.DetectFilesystem(c.LoopConfig.Path)
 	if err != nil {
+		c.LoopConfig.Detach()
 		return err
 	}
 	err = cmount.Mount(c.LoopConfig.Path, c.MountDir, fsType, unix.MS_RDONLY, "")
@@ -88,6 +112,9 @@ func (c *ImmutableImage) unixMount() (err error) {
 		slog.String("loop-path", c.LoopConfig.Path), slog.String("autoFsType", fsType))
 
 	if err != nil {
+		// Detach the loop so a mount failure (e.g. a transient SD I/O error)
+		// doesn't leave an orphaned attached loop device behind.
+		c.LoopConfig.Detach()
 		return fmt.Errorf("mount: %s", err)
 	}
 

--- a/pkg/container/diskimage/reuse.go
+++ b/pkg/container/diskimage/reuse.go
@@ -1,0 +1,117 @@
+//go:build linux
+
+package diskimage
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ahmetozer/sandal/pkg/env"
+	"github.com/ahmetozer/sandal/pkg/lib/loopdev"
+)
+
+// normRun collapses the /var/run -> /run symlink so mountpoint strings from
+// /proc/mounts (which the kernel reports as /run/...) compare equal to config/
+// option strings (which sandal writes as /var/run/...).
+func normRun(p string) string {
+	if rest, ok := strings.CutPrefix(p, "/var/run/"); ok {
+		return "/run/" + rest
+	}
+	return p
+}
+
+// loopReuseMatch reports whether an existing loop's geometry is a valid reuse
+// target for a desired mount. Match key = (backing file, offset, sizelimit);
+// a deleted backing (image replaced since attach) is never reused.
+func loopReuseMatch(haveFile string, haveDeleted bool, haveOff, haveSize uint64, wantFile string, wantOff, wantSize uint64) bool {
+	if haveDeleted {
+		return false
+	}
+	return haveFile == wantFile && haveOff == wantOff && haveSize == wantSize
+}
+
+// parseImmutableMounts returns loopNo -> mountpoint for every mount directly
+// under immBase. The loop number is the mountpoint basename (sandal names
+// immutable mount dirs by loop number). Paths are normalized for /var/run.
+func parseImmutableMounts(procMounts, immBase string) map[int]string {
+	base := normRun(filepath.Clean(immBase))
+	out := map[int]string{}
+	for _, line := range strings.Split(procMounts, "\n") {
+		f := strings.Fields(line)
+		if len(f) < 2 {
+			continue
+		}
+		mp := f[1]
+		norm := normRun(filepath.Clean(mp))
+		if filepath.Dir(norm) != base {
+			continue
+		}
+		no, err := strconv.Atoi(filepath.Base(norm))
+		if err != nil {
+			continue
+		}
+		out[no] = mp
+	}
+	return out
+}
+
+// overlayReferencesImmutable reports whether any overlay mount in procMounts
+// has a lowerdir entry referencing mountDir (normalized). Used as the teardown
+// guard: a shared immutable must stay mounted while a sibling overlay uses it.
+func overlayReferencesImmutable(mountDir, procMounts string) bool {
+	want := normRun(filepath.Clean(mountDir))
+	for _, line := range strings.Split(procMounts, "\n") {
+		f := strings.Fields(line)
+		if len(f) < 4 || f[2] != "overlay" {
+			continue
+		}
+		for _, opt := range strings.Split(f[3], ",") {
+			val, ok := strings.CutPrefix(opt, "lowerdir=")
+			if !ok {
+				continue
+			}
+			for _, d := range strings.Split(val, ":") {
+				if normRun(filepath.Clean(d)) == want {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func readProcMounts() string {
+	data, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// findMountedImmutable looks for an already-mounted immutable image whose loop
+// device backs the same file at the same offset/sizelimit, so it can be reused
+// instead of allocating a new loop. Returns the existing mount dir + loop number.
+func findMountedImmutable(wantFile string, wantOff, wantSize uint64) (mountDir string, loopNo int, found bool) {
+	// The kernel records the loop's backing_file as an absolute path, so compare
+	// against the absolute form (a -lw path may be relative to cwd).
+	want := filepath.Clean(wantFile)
+	if abs, err := filepath.Abs(want); err == nil {
+		want = abs
+	}
+	for no, mp := range parseImmutableMounts(readProcMounts(), env.BaseImmutableImageDir) {
+		path, deleted := loopdev.BackingRaw(no)
+		if loopReuseMatch(path, deleted, loopdev.Offset(no), loopdev.SizeLimit(no), want, wantOff, wantSize) {
+			return mp, no, true
+		}
+	}
+	return "", 0, false
+}
+
+// ImmutableInUse reports whether a live overlay still references mountDir as a
+// lowerdir. Teardown uses it to avoid unmounting a base image shared with a
+// still-running container.
+func ImmutableInUse(mountDir string) bool {
+	return overlayReferencesImmutable(mountDir, readProcMounts())
+}

--- a/pkg/container/diskimage/reuse_test.go
+++ b/pkg/container/diskimage/reuse_test.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package diskimage
+
+import "testing"
+
+func TestLoopReuseMatch(t *testing.T) {
+	const f = "/img/klipper.sq"
+	cases := []struct {
+		name                            string
+		haveFile                        string
+		haveDeleted                     bool
+		haveOff, haveSize               uint64
+		wantFile                        string
+		wantOff, wantSize               uint64
+		match                           bool
+	}{
+		{"exact whole-file", f, false, 0, 0, f, 0, 0, true},
+		{"exact partition", f, false, 1048576, 0, f, 1048576, 0, true},
+		{"different offset (other partition)", f, false, 0, 0, f, 1048576, 0, false},
+		{"deleted backing", f, true, 0, 0, f, 0, 0, false},
+		{"different file", "/img/other.sq", false, 0, 0, f, 0, 0, false},
+		{"different sizelimit", f, false, 0, 4096, f, 0, 0, false},
+	}
+	for _, tc := range cases {
+		got := loopReuseMatch(tc.haveFile, tc.haveDeleted, tc.haveOff, tc.haveSize, tc.wantFile, tc.wantOff, tc.wantSize)
+		if got != tc.match {
+			t.Errorf("%s: loopReuseMatch = %v, want %v", tc.name, got, tc.match)
+		}
+	}
+}
+
+const sampleMounts = `/dev/loop1 /run/sandal/immutable/1 squashfs ro,relatime 0 0
+/dev/loop2 /run/sandal/immutable/2 squashfs ro,relatime 0 0
+/dev/loop3 /run/sandal/immutable/3 squashfs ro,relatime 0 0
+overlay /run/sandal/rootfs/klipper overlay rw,relatime,lowerdir=/var/run/sandal/immutable/3,upperdir=/var/run/sandal/tmpfs/changes/klipper/upper,workdir=/var/run/sandal/tmpfs/changes/klipper/work 0 0
+proc /proc proc rw,relatime 0 0
+`
+
+func TestParseImmutableMounts(t *testing.T) {
+	got := parseImmutableMounts(sampleMounts, "/var/run/sandal/immutable")
+	if len(got) != 3 {
+		t.Fatalf("got %d immutable mounts, want 3: %v", len(got), got)
+	}
+	for _, no := range []int{1, 2, 3} {
+		if _, ok := got[no]; !ok {
+			t.Errorf("missing loop %d", no)
+		}
+	}
+	// rootfs overlays and /proc must NOT be counted as immutable mounts.
+	if len(got) != 3 {
+		t.Errorf("unexpected extra entries: %v", got)
+	}
+}
+
+func TestOverlayReferencesImmutable(t *testing.T) {
+	// loop3 is referenced by klipper's overlay lowerdir (written as /var/run/...).
+	if !overlayReferencesImmutable("/run/sandal/immutable/3", sampleMounts) {
+		t.Error("immutable/3 should be reported in-use (klipper overlay lowerdir)")
+	}
+	// loop1/loop2 are mounted but no overlay references them -> not in use.
+	if overlayReferencesImmutable("/run/sandal/immutable/1", sampleMounts) {
+		t.Error("immutable/1 should NOT be reported in-use")
+	}
+	// querying with the /var/run form must also match (normalization).
+	if !overlayReferencesImmutable("/var/run/sandal/immutable/3", sampleMounts) {
+		t.Error("immutable/3 (/var/run form) should be reported in-use")
+	}
+}

--- a/pkg/container/host/crun.go
+++ b/pkg/container/host/crun.go
@@ -21,8 +21,16 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Container run time
-func crun(c *config.Config, imageEnv []string) (int, error) {
+// Container run time.
+//
+// onPlaced, if non-nil, is invoked exactly once right after the child's pid+
+// identity have been published — i.e. once placement is committed and a
+// concurrent IsContainerRunning would observe this container. Callers pass the
+// lifecycle-lock release here so the lock is dropped as soon as placement is
+// done, rather than being held across the (possibly long-lived) foreground
+// Wait. It is NOT called on the daemon-delegation early return, where no local
+// placement happens.
+func crun(c *config.Config, imageEnv []string, onPlaced func()) (exitCode int, retErr error) {
 	c.Status = crt.ContainerStatusCreating
 	var err error
 
@@ -154,6 +162,47 @@ func crun(c *config.Config, imageEnv []string) (int, error) {
 
 	c.ContPid = cmd.Process.Pid
 
+	// Capture the kernel start-time so the recorded pid carries a stable
+	// identity (defeats PID reuse), then persist pid+identity IMMEDIATELY —
+	// before any provisioning below that can fail or be interrupted by daemon
+	// shutdown. Otherwise that window leaves a live child the daemon doesn't
+	// track, and the next health tick starts a duplicate (audit L1/L4).
+	if st, stErr := crt.ProcessStartTime(c.ContPid); stErr == nil {
+		c.ContPidStart = st
+	} else {
+		slog.Warn("crun: capture start-time", "pid", c.ContPid, "error", stErr)
+	}
+	c.Status = crt.ContainerStatusRunning
+	if perr := controller.SetContainer(c); perr != nil {
+		slog.Warn("crun: persist pid", "name", c.Name, "error", perr)
+	}
+
+	// Placement is committed: the pid+identity are published, so a concurrent
+	// run/recover will now see this container as running. Drop the lifecycle
+	// lock (if the caller passed its release here) so it isn't held across the
+	// veth setup below or the long-lived foreground Wait — otherwise a
+	// `sandal kill`/`stop`/`rm` of this container would block on the lock.
+	if onPlaced != nil {
+		onPlaced()
+	}
+
+	// childOwned flips true once the child is handed to the background wait
+	// goroutine or reaped by the inline foreground Wait. Until then, any error
+	// return must not leak the running child: the deferred guard kills+reaps it
+	// and clears the persisted identity so no orphan survives and the recorded
+	// pid never points at a dead/abandoned process (audit L1/L4).
+	childOwned := false
+	defer func() {
+		if retErr != nil && !childOwned {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+			c.ContPid = 0
+			c.ContPidStart = 0
+			c.Status = fmt.Sprintf("err %v", retErr)
+			controller.SetContainer(c)
+		}
+	}()
+
 	// Close the slave PTY fd in the parent now that the child has inherited it.
 	// This ensures when the child exits, all slave fds are closed and master
 	// read returns EIO, allowing the relay goroutine to terminate.
@@ -174,8 +223,7 @@ func crun(c *config.Config, imageEnv []string) (int, error) {
 	}
 
 	// c.NS.LoadNamespaceIDs(c.ContPid)
-
-	c.Status = crt.ContainerStatusRunning
+	// (status was set to running and persisted right after cmd.Start above.)
 
 	// Skip link creation when the container shares the host netns
 	// (nothing to provision) or joins an existing one via --ns-net <target>
@@ -290,6 +338,7 @@ func crun(c *config.Config, imageEnv []string) (int, error) {
 		// session and orphan the old listener (port stuck "in use").
 		ownedSession := session
 		registered := env.IsDaemon && session != nil
+		childOwned = true // the wait goroutine below now owns reaping
 		go func() {
 			cmd.Process.Wait()
 			if registered {
@@ -306,6 +355,7 @@ func crun(c *config.Config, imageEnv []string) (int, error) {
 	}
 
 	sig, err := cmd.Process.Wait()
+	childOwned = true // child reaped inline; no orphan for the deferred guard
 	if err != nil && err.Error() == "waitid: no child processes" {
 		err = nil
 	}

--- a/pkg/container/host/derun.go
+++ b/pkg/container/host/derun.go
@@ -92,14 +92,11 @@ func reclaimStaleImmutableMounts(c *config.Config) {
 			prev = c2
 			continue
 		}
-		pid := c2.ContPid
-		if c2.VM != "" {
-			pid = c2.HostPid
-		}
+		pid, wantStart := c2.MonitorPidIdentity()
 		if pid == 0 {
 			continue
 		}
-		if alive, _ := crt.IsPidRunning(pid); !alive {
+		if alive, _ := crt.IsPidRunningAs(pid, wantStart); !alive {
 			continue
 		}
 		for j := range c2.ImmutableImages {

--- a/pkg/container/host/derun.go
+++ b/pkg/container/host/derun.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ahmetozer/sandal/pkg/container/host/clean"
 	"github.com/ahmetozer/sandal/pkg/container/net"
 	"github.com/ahmetozer/sandal/pkg/container/resources"
+	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
 	"github.com/ahmetozer/sandal/pkg/lib/loopdev"
 	"github.com/vishvananda/netlink"
@@ -69,8 +70,44 @@ func CleanupResources(c *config.Config) {
 // container would tear down that live container's rootfs — the backing-file
 // check prevents that.
 func reclaimStaleImmutableMounts(c *config.Config) {
-	prev, err := controller.GetContainer(c.Name)
-	if err != nil || prev == nil {
+	conts, err := controller.Containers()
+	if err != nil {
+		return
+	}
+
+	// busyLoops holds loop numbers currently claimed by *other* live
+	// containers. The immutable mount dir is keyed by loop number, so a loop
+	// that a running sibling re-acquired (e.g. two containers sharing a base
+	// image that landed on the same loop number) must never be reclaimed
+	// here — unmounting it would pull the rootfs lowerdir out from under that
+	// sibling. The backing-file check can't catch this on its own because the
+	// sibling may legitimately back the *same* file.
+	var prev *config.Config
+	busyLoops := map[int]struct{}{}
+	for _, c2 := range conts {
+		if c2 == nil {
+			continue
+		}
+		if c2.Name == c.Name {
+			prev = c2
+			continue
+		}
+		pid := c2.ContPid
+		if c2.VM != "" {
+			pid = c2.HostPid
+		}
+		if pid == 0 {
+			continue
+		}
+		if alive, _ := crt.IsPidRunning(pid); !alive {
+			continue
+		}
+		for j := range c2.ImmutableImages {
+			busyLoops[c2.ImmutableImages[j].LoopConfig.No] = struct{}{}
+		}
+	}
+
+	if prev == nil {
 		return
 	}
 
@@ -79,8 +116,12 @@ func reclaimStaleImmutableMounts(c *config.Config) {
 		if c.ImmutableImages.Contains(sq) {
 			continue // current run owns this image; normal cleanup handles it
 		}
+		if _, busy := busyLoops[sq.LoopConfig.No]; busy {
+			slog.Debug("reclaimStaleImmutableMounts", slog.String("cont", c.Name), slog.Int("loop", sq.LoopConfig.No), slog.String("msg", "loop held by live sibling, skipping"))
+			continue
+		}
 		if loopdev.BackingFile(sq.LoopConfig.No) != filepath.Clean(sq.File) {
-			continue // loop detached or reused by another container — leave it
+			continue // loop detached or reused by another file — leave it
 		}
 		if err := diskimage.Umount(&sq); err != nil {
 			slog.Debug("reclaimStaleImmutableMounts", slog.String("cont", c.Name), slog.String("file", sq.File), slog.Int("loop", sq.LoopConfig.No), slog.Any("error", err))

--- a/pkg/container/host/derun.go
+++ b/pkg/container/host/derun.go
@@ -5,12 +5,16 @@ package host
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/ahmetozer/sandal/pkg/container/config"
 	"github.com/ahmetozer/sandal/pkg/container/console"
+	"github.com/ahmetozer/sandal/pkg/container/diskimage"
 	"github.com/ahmetozer/sandal/pkg/container/host/clean"
 	"github.com/ahmetozer/sandal/pkg/container/net"
 	"github.com/ahmetozer/sandal/pkg/container/resources"
+	"github.com/ahmetozer/sandal/pkg/controller"
+	"github.com/ahmetozer/sandal/pkg/lib/loopdev"
 	"github.com/vishvananda/netlink"
 )
 
@@ -53,7 +57,40 @@ func CleanupResources(c *config.Config) {
 	}
 }
 
+// reclaimStaleImmutableMounts unmounts squashfs/loop images recorded by a
+// previous run of this container that the in-memory config doesn't know
+// about. A fresh `sandal run` builds its config from CLI flags, so
+// c.ImmutableImages is empty and CleanupResources would otherwise leave the
+// prior run's loop mounts under /run/sandal/immutable orphaned.
+//
+// Each reclaim is gated on the loop device still backing the exact file the
+// dead run recorded. The immutable mount dir is shared by loop number across
+// all containers, so detaching a loop that has since been reused by another
+// container would tear down that live container's rootfs — the backing-file
+// check prevents that.
+func reclaimStaleImmutableMounts(c *config.Config) {
+	prev, err := controller.GetContainer(c.Name)
+	if err != nil || prev == nil {
+		return
+	}
+
+	for i := range prev.ImmutableImages {
+		sq := prev.ImmutableImages[i]
+		if c.ImmutableImages.Contains(sq) {
+			continue // current run owns this image; normal cleanup handles it
+		}
+		if loopdev.BackingFile(sq.LoopConfig.No) != filepath.Clean(sq.File) {
+			continue // loop detached or reused by another container — leave it
+		}
+		if err := diskimage.Umount(&sq); err != nil {
+			slog.Debug("reclaimStaleImmutableMounts", slog.String("cont", c.Name), slog.String("file", sq.File), slog.Int("loop", sq.LoopConfig.No), slog.Any("error", err))
+		}
+	}
+}
+
 func DeRunContainer(c *config.Config) {
+	reclaimStaleImmutableMounts(c)
+
 	CleanupResources(c)
 
 	Kill(c, 9, 5)

--- a/pkg/container/host/kill.go
+++ b/pkg/container/host/kill.go
@@ -32,42 +32,39 @@ func Kill(c *config.Config, signal int, second int) error {
 		}
 		return nil
 	}
-	ch := make(chan bool, 1)
-	kill := make(chan bool)
+	pid := c.ContPid
 
-	go func(killed chan<- bool) {
-		// SendSig(c.HostPid, 9)
-		crt.SendSig(c.ContPid, signal)
-		for {
-			b, _ := crt.IsPidRunning(c.ContPid)
-			if !b {
-				killed <- true
-				break
-			}
-			time.Sleep(1 * time.Second)
-		}
-	}(kill)
+	// Deliver the signal once.
+	crt.SendSig(pid, signal)
 
-	if second >= 0 {
-		select {
-		case ret := <-kill:
-			ch <- ret
-		case <-time.After(time.Duration(second) * time.Second):
-			ch <- false
-		}
-	} else {
-		// Wait until exits
-		ch <- <-kill
+	// second == 0: fire-and-forget. Deliver the signal and return without
+	// waiting or tearing down state. The signal proxy, zombie reaper, and
+	// recovery's last-resort SIGKILL all pass 0 and poll for exit themselves;
+	// they must not block here and must not trigger cleanup on a process that
+	// may still be alive.
+	if second == 0 {
+		return nil
 	}
 
-	stat := <-ch
-
-	if !stat {
-		if second >= 0 {
-			return fmt.Errorf("unable to kill container pid %d in %d second", c.ContPid, second)
+	// Wait for the process to actually exit. second < 0 waits indefinitely;
+	// second > 0 polls until the deadline. There is no background goroutine,
+	// so nothing can leak; reading /proc never blocks (even for D-state pids),
+	// so the caller is blocked for at most `second`.
+	deadline := time.Now().Add(time.Duration(second) * time.Second)
+	exited := false
+	for {
+		if alive, _ := crt.IsPidRunning(pid); !alive {
+			exited = true
+			break
 		}
-		return fmt.Errorf("unable to kill container pid: %d", c.ContPid)
+		if second > 0 && !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 
+	if !exited {
+		return fmt.Errorf("unable to kill container pid %d in %d second", pid, second)
 	}
 
 	c.Status = "killed"

--- a/pkg/container/host/kill.go
+++ b/pkg/container/host/kill.go
@@ -34,6 +34,17 @@ func Kill(c *config.Config, signal int, second int) error {
 	}
 	pid := c.ContPid
 
+	// Identity guard: only signal if pid is still THIS container. If it's dead,
+	// or recycled to an unrelated process (different start-time), signalling it
+	// would kill an innocent process — treat it as already stopped and clean up.
+	if alive, _ := crt.IsPidRunningAs(pid, c.ContPidStart); !alive {
+		c.Status = "killed"
+		c.ContPid = 0
+		c.ContPidStart = 0
+		CleanupResources(c)
+		return controller.SetContainer(c)
+	}
+
 	// Deliver the signal once.
 	crt.SendSig(pid, signal)
 
@@ -53,7 +64,9 @@ func Kill(c *config.Config, signal int, second int) error {
 	deadline := time.Now().Add(time.Duration(second) * time.Second)
 	exited := false
 	for {
-		if alive, _ := crt.IsPidRunning(pid); !alive {
+		// Identity-aware so our process exiting (even if the pid is instantly
+		// recycled by an unrelated process) counts as exited.
+		if alive, _ := crt.IsPidRunningAs(pid, c.ContPidStart); !alive {
 			exited = true
 			break
 		}
@@ -69,6 +82,7 @@ func Kill(c *config.Config, signal int, second int) error {
 
 	c.Status = "killed"
 	c.ContPid = 0
+	c.ContPidStart = 0
 	CleanupResources(c)
 	controller.SetContainer(c)
 

--- a/pkg/container/host/kill_darwin.go
+++ b/pkg/container/host/kill_darwin.go
@@ -36,39 +36,35 @@ func Kill(c *config.Config, signal int, second int) error {
 		return nil
 	}
 
-	ch := make(chan bool, 1)
-	kill := make(chan bool)
+	// Deliver the signal once.
+	crt.SendSig(pid, signal)
 
-	go func(killed chan<- bool) {
-		crt.SendSig(pid, signal)
-		for {
-			b, _ := crt.IsPidRunning(pid)
-			if !b {
-				killed <- true
-				break
-			}
-			time.Sleep(1 * time.Second)
-		}
-	}(kill)
-
-	if second >= 0 {
-		select {
-		case ret := <-kill:
-			ch <- ret
-		case <-time.After(time.Duration(second) * time.Second):
-			ch <- false
-		}
-	} else {
-		ch <- <-kill
+	// second == 0: fire-and-forget. Deliver the signal and return without
+	// waiting or tearing down state. Callers that pass 0 poll for exit
+	// themselves and must not block here or trigger cleanup on a process
+	// that may still be alive.
+	if second == 0 {
+		return nil
 	}
 
-	stat := <-ch
-
-	if !stat {
-		if second >= 0 {
-			return fmt.Errorf("unable to kill container pid %d in %d second", pid, second)
+	// Wait for the process to actually exit. second < 0 waits indefinitely;
+	// second > 0 polls until the deadline. No background goroutine, so
+	// nothing can leak; the caller is blocked for at most `second`.
+	deadline := time.Now().Add(time.Duration(second) * time.Second)
+	exited := false
+	for {
+		if alive, _ := crt.IsPidRunning(pid); !alive {
+			exited = true
+			break
 		}
-		return fmt.Errorf("unable to kill container pid: %d", pid)
+		if second > 0 && !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if !exited {
+		return fmt.Errorf("unable to kill container pid %d in %d second", pid, second)
 	}
 
 	c.Status = "killed"

--- a/pkg/container/host/rootfs.go
+++ b/pkg/container/host/rootfs.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ahmetozer/sandal/pkg/container/config"
 	"github.com/ahmetozer/sandal/pkg/container/diskimage"
@@ -75,7 +76,11 @@ func resolveLowerSource(c *config.Config, basePath, fullSource string) (string, 
 			progressCh := make(chan progress.Event, 16)
 			renderDone := progress.StartRenderer(progressCh, os.Stderr)
 
-			sqfsPath, pullErr := containerimage.Pull(context.Background(), fullSource, env.BaseImageDir, progressCh)
+			// Bound the pull so a stalled registry can't wedge a recovery
+			// goroutine forever (see daemon health-check recovery guard).
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			sqfsPath, pullErr := containerimage.Pull(ctx, fullSource, env.BaseImageDir, progressCh)
+			cancel()
 			close(progressCh)
 			<-renderDone
 

--- a/pkg/container/host/rootfs.go
+++ b/pkg/container/host/rootfs.go
@@ -332,11 +332,13 @@ func UmountRootfs(c *config.Config) []error {
 	// Skipped when the caller manages the change-dir backing across
 	// multiple runs (sandal build, see ChangeDirManaged).
 	if !c.ChangeDirManaged {
-		if mount := overlayfs.GetImageChangeMount(c.ChangeDir); mount != nil {
+		// Atomically claim-and-remove the mount so a concurrent teardown of the
+		// same change dir can't observe the same entry and Cleanup() it twice
+		// (double unmount / loop-detach). Cleanup runs outside the registry lock.
+		if mount := overlayfs.TakeImageChangeMount(c.ChangeDir); mount != nil {
 			if cleanupErr := mount.Cleanup(); cleanupErr != nil {
 				errs = append(errs, fmt.Errorf("image change dir cleanup: %w", cleanupErr))
 			}
-			overlayfs.UnregisterImageChangeMount(c.ChangeDir)
 		}
 
 		// Clean up stale change dir mounts from previous runs whose

--- a/pkg/container/host/rootfs.go
+++ b/pkg/container/host/rootfs.go
@@ -358,8 +358,14 @@ func UmountRootfs(c *config.Config) []error {
 	}
 
 	for _, sq := range c.ImmutableImages {
-		err := diskimage.Umount(&sq)
-		if err != nil {
+		// Don't unmount a base image that another live container's overlay still
+		// references — immutable mounts are shared read-only and reused across
+		// containers (the container's own overlay was already unmounted above).
+		if diskimage.ImmutableInUse(sq.MountDir) {
+			slog.Debug("UmountRootfs", slog.String("action", "keep shared immutable"), slog.String("mountDir", sq.MountDir))
+			continue
+		}
+		if err := diskimage.Umount(&sq); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/container/host/run.go
+++ b/pkg/container/host/run.go
@@ -29,6 +29,12 @@ func Run(c *config.Config, onPlaced func()) error {
 	// mount squasfs
 	squashfsImages, err := mountRootfs(c)
 	if err != nil {
+		// mountRootfs may have already mounted some immutable lower images
+		// before failing (e.g. a transient squashfs/overlay error after one
+		// loop was mounted). Tear those partial mounts down so a failed
+		// (re)start can't leak loop devices / immutable mounts (audit: the
+		// failed-recovery storm that orphaned 16 mounts on mrs2).
+		CleanupResources(c)
 		return fmt.Errorf("error mount: %v", err)
 	}
 

--- a/pkg/container/host/run.go
+++ b/pkg/container/host/run.go
@@ -10,7 +10,11 @@ import (
 	"github.com/ahmetozer/sandal/pkg/env"
 )
 
-func Run(c *config.Config) error {
+// Run sets up and starts a container. onPlaced (may be nil) is forwarded to
+// crun and invoked once the child's pid is published, so a caller holding the
+// per-name lifecycle lock can release it as soon as placement is committed
+// rather than across the foreground Wait. See crun for details.
+func Run(c *config.Config, onPlaced func()) error {
 
 	// When a startup container is delegated to the daemon, skip local
 	// cleanup and rootfs setup — the daemon will handle the full lifecycle.
@@ -62,7 +66,7 @@ func Run(c *config.Config) error {
 	controller.SetContainer(c)
 
 	// Starting proccess
-	exitCode, err := crun(c, imgEnv)
+	exitCode, err := crun(c, imgEnv, onPlaced)
 
 	if !c.Remove && !c.Background {
 		c.Status = fmt.Sprintf("exit %d", exitCode)

--- a/pkg/container/host/run_container.go
+++ b/pkg/container/host/run_container.go
@@ -8,6 +8,7 @@ import (
 	gonet "net"
 
 	"github.com/ahmetozer/sandal/pkg/container/config"
+	"github.com/ahmetozer/sandal/pkg/container/namelock"
 	"github.com/ahmetozer/sandal/pkg/container/net"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
@@ -30,6 +31,17 @@ func RunContainer(c *config.Config, networkFlags []string) error {
 	if err := config.ValidateName(c.Name); err != nil {
 		return err
 	}
+
+	// Serialize placement per name across every process (a second CLI run, or a
+	// daemon recovery) so two actors can't both pass the "already running" check
+	// below and double-start the container, leaving one instance detached
+	// (audit L3). Held across crun's first pid-publishing SetContainer; inner
+	// helpers (Run/crun/DeRunContainer/Kill) run under it and never re-acquire.
+	release, err := namelock.Acquire(c.Name, namelock.DefaultTimeout)
+	if err != nil {
+		return fmt.Errorf("acquire lifecycle lock for %q: %w", c.Name, err)
+	}
+	defer release()
 
 	conts, err := controller.Containers()
 	if err != nil {
@@ -113,5 +125,8 @@ func RunContainer(c *config.Config, networkFlags []string) error {
 		}
 	}
 
-	return Run(c)
+	// Pass release as onPlaced so the lifecycle lock is dropped the moment
+	// crun publishes the pid, not held across a foreground container's lifetime.
+	// The deferred release above is then an idempotent no-op.
+	return Run(c, release)
 }

--- a/pkg/container/namelock/namelock.go
+++ b/pkg/container/namelock/namelock.go
@@ -1,0 +1,97 @@
+//go:build linux || darwin
+
+// Package namelock provides a per-container-name lifecycle lock used to
+// serialize placement and teardown (run / recover / kill / rm) across every
+// process — the CLI and the daemon — and across the daemon's own goroutines.
+//
+// It is backed by an flock on <RunDir>/locks/<name>.lock. Because flock is tied
+// to the open file description, the lock is released automatically if the holder
+// process dies, so a crashed CLI or daemon never leaves a name wedged.
+//
+// Ownership contract: acquire ONCE at the outermost lifecycle entry
+// (RunContainer, contRecover, KillByName, rm/clear) and hold it across the whole
+// critical section. Inner helpers (Run, crun, DeRunContainer, Kill) assume the
+// lock is held and must NOT re-acquire it: flock treats two independent opens in
+// the same process as contending, so a nested Acquire would deadlock.
+package namelock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/ahmetozer/sandal/pkg/env"
+	"github.com/ahmetozer/sandal/pkg/lib/flock"
+)
+
+const pollInterval = 50 * time.Millisecond
+
+// DefaultTimeout bounds how long a blocking Acquire waits before failing. Long
+// enough to ride out a brief teardown by another actor, short enough that a CLI
+// command doesn't hang indefinitely behind a stuck holder.
+const DefaultTimeout = 30 * time.Second
+
+// releaseOnce wraps Unlock so a release func can be called more than once
+// safely (e.g. an explicit release followed by a deferred release).
+func releaseOnce(l *flock.Lock) func() {
+	var once sync.Once
+	return func() { once.Do(func() { _ = l.Unlock() }) }
+}
+
+func lockDir() string { return filepath.Join(env.RunDir, "locks") }
+
+func open(name string) (*flock.Lock, error) {
+	dir := lockDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create lock dir %q: %w", dir, err)
+	}
+	return flock.Open(filepath.Join(dir, name+".lock"))
+}
+
+// TryAcquire takes the lifecycle lock for name without blocking. On success it
+// returns a release func and ok=true; if another holder owns the name it returns
+// (nil, false, nil). The caller must call release exactly once when done.
+func TryAcquire(name string) (release func(), ok bool, err error) {
+	l, err := open(name)
+	if err != nil {
+		return nil, false, err
+	}
+	got, err := l.TryLock()
+	if err != nil {
+		_ = l.Unlock()
+		return nil, false, err
+	}
+	if !got {
+		_ = l.Unlock()
+		return nil, false, nil
+	}
+	return releaseOnce(l), true, nil
+}
+
+// Acquire blocks until the lifecycle lock for name is held or timeout elapses.
+// A negative timeout blocks indefinitely. On success it returns a release func
+// the caller must invoke exactly once.
+func Acquire(name string, timeout time.Duration) (release func(), err error) {
+	l, err := open(name)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		got, lerr := l.TryLock()
+		if lerr != nil {
+			_ = l.Unlock()
+			return nil, lerr
+		}
+		if got {
+			return releaseOnce(l), nil
+		}
+		if timeout >= 0 && !time.Now().Before(deadline) {
+			_ = l.Unlock()
+			return nil, fmt.Errorf("timeout acquiring lifecycle lock for %q after %s", name, timeout)
+		}
+		time.Sleep(pollInterval)
+	}
+}

--- a/pkg/container/namelock/namelock_test.go
+++ b/pkg/container/namelock/namelock_test.go
@@ -1,0 +1,60 @@
+//go:build linux || darwin
+
+package namelock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ahmetozer/sandal/pkg/env"
+)
+
+func TestTryAcquireMutualExclusion(t *testing.T) {
+	env.RunDir = t.TempDir()
+
+	rel, ok, err := TryAcquire("web")
+	if err != nil || !ok {
+		t.Fatalf("first TryAcquire = (%v,%v), want (true,nil)", ok, err)
+	}
+
+	if rel2, ok2, err := TryAcquire("web"); err != nil || ok2 {
+		if rel2 != nil {
+			rel2()
+		}
+		t.Fatalf("second TryAcquire while held = (%v,%v), want (false,nil)", ok2, err)
+	}
+
+	// A different name is independent.
+	relOther, okOther, err := TryAcquire("db")
+	if err != nil || !okOther {
+		t.Fatalf("TryAcquire(db) = (%v,%v), want (true,nil)", okOther, err)
+	}
+	relOther()
+
+	// After release, the name is acquirable again.
+	rel()
+	rel3, ok3, err := TryAcquire("web")
+	if err != nil || !ok3 {
+		t.Fatalf("re-acquire after release = (%v,%v), want (true,nil)", ok3, err)
+	}
+	rel3()
+}
+
+func TestAcquireBlocksUntilTimeout(t *testing.T) {
+	env.RunDir = t.TempDir()
+
+	rel, ok, err := TryAcquire("x")
+	if err != nil || !ok {
+		t.Fatalf("setup TryAcquire failed: ok=%v err=%v", ok, err)
+	}
+	defer rel()
+
+	start := time.Now()
+	if rel2, err := Acquire("x", 150*time.Millisecond); err == nil {
+		rel2()
+		t.Fatal("Acquire should time out while the name is held")
+	}
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("Acquire returned after %s, expected to wait ~150ms", elapsed)
+	}
+}

--- a/pkg/container/net/addr.go
+++ b/pkg/container/net/addr.go
@@ -3,6 +3,7 @@
 package net
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -10,6 +11,14 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
+
+// errIsEEXIST reports whether err is (or wraps) EEXIST. Used to tolerate
+// re-adding an address that is already present. Uses errors.Is rather than a
+// type assertion so a wrapped error (fmt.wrapError, *os.SyscallError, *net.OpError
+// from the netlink receive path) is classified instead of panicking the process.
+func errIsEEXIST(err error) bool {
+	return errors.Is(err, unix.EEXIST)
+}
 
 type Addr struct {
 	IP    net.IP
@@ -70,8 +79,9 @@ func (a Addr) Add(link netlink.Link) error {
 	}
 
 	if err := netlink.AddrAdd(link, addrNet); err != nil {
-		// if its not file exists error, return error
-		if unix.Errno(err.(unix.Errno)) != unix.EEXIST {
+		// Tolerate "already exists"; surface anything else. errors.Is (not a
+		// type assertion) so a wrapped non-Errno error doesn't panic.
+		if !errIsEEXIST(err) {
 			return err
 		}
 	}

--- a/pkg/container/net/addr_test.go
+++ b/pkg/container/net/addr_test.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package net
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// errIsEEXIST must classify "already exists" without panicking on wrapped
+// errors. The old code used `err.(unix.Errno)` (single-value assertion), which
+// panics for any non-bare-Errno error (e.g. a fmt.wrapError or *os.SyscallError
+// returned from the netlink receive path), crashing the process.
+func TestErrIsEEXIST(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"bare EEXIST", unix.EEXIST, true},
+		{"bare syscall EEXIST", syscall.EEXIST, true},
+		{"wrapped EEXIST", fmt.Errorf("add addr: %w", unix.EEXIST), true},
+		{"other bare errno", unix.ENOBUFS, false},
+		{"wrapped non-errno (would panic old code)", fmt.Errorf("wrong sender portid"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := errIsEEXIST(tc.err); got != tc.want {
+				t.Fatalf("errIsEEXIST(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/container/overlayfs/imagechanges.go
+++ b/pkg/container/overlayfs/imagechanges.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 
 	"github.com/ahmetozer/sandal/pkg/container/resources"
 	cmount "github.com/ahmetozer/sandal/pkg/container/mount"
@@ -27,18 +28,45 @@ type ImageChangeMount struct {
 }
 
 // imageChangeMounts tracks active image-backed change dir mounts for cleanup.
-var imageChangeMounts = map[string]*ImageChangeMount{}
+// It is a process-global shared by concurrent daemon recovery goroutines (the
+// `recovering` map only serializes per name, so different-named recoveries run
+// in parallel and hit this map at the same time). imageChangeMountsMu guards
+// every access; without it concurrent Register/Unregister fatal the daemon with
+// an unrecoverable "concurrent map writes".
+var (
+	imageChangeMounts   = map[string]*ImageChangeMount{}
+	imageChangeMountsMu sync.Mutex
+)
 
 func RegisterImageChangeMount(changeDir string, mount *ImageChangeMount) {
+	imageChangeMountsMu.Lock()
+	defer imageChangeMountsMu.Unlock()
 	imageChangeMounts[changeDir] = mount
 }
 
 func GetImageChangeMount(changeDir string) *ImageChangeMount {
+	imageChangeMountsMu.Lock()
+	defer imageChangeMountsMu.Unlock()
 	return imageChangeMounts[changeDir]
 }
 
 func UnregisterImageChangeMount(changeDir string) {
+	imageChangeMountsMu.Lock()
+	defer imageChangeMountsMu.Unlock()
 	delete(imageChangeMounts, changeDir)
+}
+
+// TakeImageChangeMount atomically returns and removes the mount for changeDir.
+// Callers tearing a mount down use this so the lookup and removal happen under
+// one lock: two goroutines can't both observe the same entry and Cleanup() it
+// twice (a double unmount/loop-detach). Returns nil if absent. Cleanup() should
+// be called on the result OUTSIDE the lock since it does slow unmount/detach I/O.
+func TakeImageChangeMount(changeDir string) *ImageChangeMount {
+	imageChangeMountsMu.Lock()
+	defer imageChangeMountsMu.Unlock()
+	m := imageChangeMounts[changeDir]
+	delete(imageChangeMounts, changeDir)
+	return m
 }
 
 // prepareImageChangeDir creates a sparse ext4 disk image, loop-mounts it,

--- a/pkg/container/overlayfs/imagechanges_test.go
+++ b/pkg/container/overlayfs/imagechanges_test.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+package overlayfs
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestImageChangeMountsConcurrentAccess exercises the registry from multiple
+// goroutines hitting overlapping keys. This mirrors the daemon's per-name
+// recovery goroutines (which run fully concurrently — `recovering` only
+// serializes per name) each driving the image-backed change-dir path:
+// UmountRootfs -> UnregisterImageChangeMount (delete) racing
+// mountRootfs -> RegisterImageChangeMount (write) on the shared global map.
+//
+// Without synchronization this fatals with "concurrent map writes" — Go's
+// runtime detects concurrent map mutation even without the race detector
+// (which is unavailable on some hosts) and the fatal is NOT recoverable, so
+// it takes down the whole daemon. A single hot key under many goroutines
+// triggers it reliably.
+func TestImageChangeMountsConcurrentAccess(t *testing.T) {
+	const goroutines = 16
+	const iters = 20000
+	const key = "/change/hot"
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				RegisterImageChangeMount(key, &ImageChangeMount{MountPoint: key})
+				_ = GetImageChangeMount(key)
+				UnregisterImageChangeMount(key)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/container/runtime/status.go
+++ b/pkg/container/runtime/status.go
@@ -18,11 +18,8 @@ const (
 func IsContainerRunning(name string) (bool, error) {
 	oldConfig, err := controller.GetContainer(name)
 	if err == nil {
-		pid := oldConfig.ContPid
-		if pid == 0 && oldConfig.VM != "" {
-			pid = oldConfig.HostPid
-		}
-		b, err := IsPidRunning(pid)
+		pid, wantStart := oldConfig.MonitorPidIdentity()
+		b, err := IsPidRunningAs(pid, wantStart)
 		if err != nil && pid != 0 {
 			return false, fmt.Errorf("unable to check pid %d: %v", pid, err)
 		}
@@ -33,6 +30,43 @@ func IsContainerRunning(name string) (bool, error) {
 
 func SendSig(pid, sig int) error {
 	return syscall.Kill(pid, syscall.Signal(sig))
+}
+
+// ProcessStartTime returns the kernel start-time identity for pid (0 on
+// platforms with no such notion). Pairing pid with start-time makes liveness
+// and kill checks immune to PID reuse: a recycled pid has a different
+// start-time. Returns 0 for non-positive pids.
+func ProcessStartTime(pid int) (uint64, error) {
+	if pid <= 0 {
+		return 0, nil
+	}
+	return processStartTime(pid)
+}
+
+// IsPidRunningAs reports whether pid is alive AND still the process we expect,
+// by comparing its start-time to wantStart. When wantStart is 0 (identity
+// unknown — e.g. a not-yet-migrated record, or a platform without start-time)
+// it degrades to a plain liveness check. A live pid whose start-time differs
+// from wantStart is treated as NOT running: it's a recycled, unrelated process.
+func IsPidRunningAs(pid int, wantStart uint64) (bool, error) {
+	alive, err := IsPidRunning(pid)
+	if err != nil || !alive {
+		return alive, err
+	}
+	if wantStart == 0 {
+		return true, nil
+	}
+	gotStart, sErr := ProcessStartTime(pid)
+	if sErr != nil {
+		// Can't read start-time for a pid we just saw alive: be conservative
+		// and report alive so we never kill/duplicate based on a transient
+		// read failure.
+		return true, nil
+	}
+	if gotStart != wantStart {
+		return false, nil
+	}
+	return true, nil
 }
 
 var ErrPidExistenceControl = fmt.Errorf("unable to find process")

--- a/pkg/container/runtime/status_darwin.go
+++ b/pkg/container/runtime/status_darwin.go
@@ -22,3 +22,9 @@ func isPidAlive(pid int) (bool, error) {
 	}
 	return true, nil
 }
+
+// processStartTime has no portable equivalent on macOS; return 0 so identity
+// checks degrade to liveness-only. The daemon container lifecycle is Linux-only.
+func processStartTime(pid int) (uint64, error) {
+	return 0, nil
+}

--- a/pkg/container/runtime/status_linux.go
+++ b/pkg/container/runtime/status_linux.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -19,4 +20,38 @@ func isPidAlive(pid int) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+// processStartTime returns the kernel start-time (field 22 of
+// /proc/<pid>/stat, in clock ticks since boot) for pid. Combined with the pid
+// it forms a stable identity that survives a daemon restart and defeats PID
+// reuse: a recycled pid will have a different start-time.
+func processStartTime(pid int) (uint64, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, err
+	}
+	return parseStartTime(string(data))
+}
+
+// parseStartTime extracts field 22 (starttime) from /proc/<pid>/stat content.
+// Field 2 (comm) is wrapped in parentheses and may itself contain spaces and
+// parentheses, so we scan for the LAST ')' and parse the space-separated fields
+// after it: the first such field is field 3 (state), so starttime (field 22)
+// is at index 22-3 = 19.
+func parseStartTime(stat string) (uint64, error) {
+	rparen := strings.LastIndexByte(stat, ')')
+	if rparen < 0 || rparen+2 >= len(stat) {
+		return 0, fmt.Errorf("malformed /proc stat: no comm field")
+	}
+	fields := strings.Fields(stat[rparen+2:])
+	const startTimeIndex = 22 - 3
+	if len(fields) <= startTimeIndex {
+		return 0, fmt.Errorf("malformed /proc stat: too few fields (%d)", len(fields))
+	}
+	st, err := strconv.ParseUint(fields[startTimeIndex], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing starttime: %w", err)
+	}
+	return st, nil
 }

--- a/pkg/container/runtime/status_linux_test.go
+++ b/pkg/container/runtime/status_linux_test.go
@@ -1,0 +1,78 @@
+//go:build linux
+
+package runtime
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// parseStartTime must read field 22 (starttime) of /proc/<pid>/stat robustly,
+// even though field 2 (comm) is parenthesized and may contain spaces and
+// parentheses. The parser locates the LAST ')' so comm content can't shift the
+// field offsets.
+func TestParseStartTime(t *testing.T) {
+	toks := make([]string, 25)
+	for i := range toks {
+		toks[i] = "0"
+	}
+	toks[19] = "99999" // field 22 = starttime; index 19 in the post-comm fields
+	// comm contains a space and an embedded ')'
+	line := "1234 (od )dd) " + strings.Join(toks, " ") + "\n"
+
+	got, err := parseStartTime(line)
+	if err != nil {
+		t.Fatalf("parseStartTime error: %v", err)
+	}
+	if got != 99999 {
+		t.Fatalf("parseStartTime = %d, want 99999", got)
+	}
+}
+
+func TestParseStartTimeMalformed(t *testing.T) {
+	for _, bad := range []string{"", "no parens here", "123 (comm) S"} {
+		if _, err := parseStartTime(bad); err == nil {
+			t.Errorf("parseStartTime(%q) expected error, got nil", bad)
+		}
+	}
+}
+
+// IsPidRunningAs must verify identity: a live pid whose start-time differs from
+// the expected one is a recycled, unrelated process and must read as not
+// running. A wantStart of 0 degrades to a plain liveness check.
+func TestIsPidRunningAsIdentity(t *testing.T) {
+	self := os.Getpid()
+	start, err := ProcessStartTime(self)
+	if err != nil || start == 0 {
+		t.Fatalf("ProcessStartTime(self) = %d, err %v", start, err)
+	}
+
+	if ok, err := IsPidRunningAs(self, start); err != nil || !ok {
+		t.Fatalf("correct identity: ok=%v err=%v, want true", ok, err)
+	}
+	if ok, _ := IsPidRunningAs(self, start+1); ok {
+		t.Fatal("mismatched start-time must report NOT running (recycled pid)")
+	}
+	if ok, err := IsPidRunningAs(self, 0); err != nil || !ok {
+		t.Fatalf("unknown start (0): ok=%v err=%v, want true (liveness only)", ok, err)
+	}
+	if ok, _ := IsPidRunningAs(-1, 0); ok {
+		t.Fatal("invalid pid must report NOT running")
+	}
+}
+
+// ProcessStartTime of our own pid must be nonzero and stable across calls.
+func TestProcessStartTimeSelfStable(t *testing.T) {
+	a, err := ProcessStartTime(os.Getpid())
+	if err != nil {
+		t.Fatalf("ProcessStartTime(self) error: %v", err)
+	}
+	if a == 0 {
+		t.Fatal("ProcessStartTime(self) = 0, want nonzero")
+	}
+	b, err := ProcessStartTime(os.Getpid())
+	if err != nil || a != b {
+		t.Fatalf("ProcessStartTime unstable: %d != %d (err %v)", a, b, err)
+	}
+}

--- a/pkg/container/runtime/status_unsupported.go
+++ b/pkg/container/runtime/status_unsupported.go
@@ -5,3 +5,7 @@ package runtime
 func isPidAlive(pid int) (bool, error) {
 	return true, nil
 }
+
+func processStartTime(pid int) (uint64, error) {
+	return 0, nil
+}

--- a/pkg/daemon/disk-events.go
+++ b/pkg/daemon/disk-events.go
@@ -5,9 +5,11 @@ package daemon
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
-	"strings"
+	"time"
 
+	"github.com/ahmetozer/sandal/pkg/container/config"
 	"github.com/ahmetozer/sandal/pkg/controller"
 	"github.com/ahmetozer/sandal/pkg/env"
 	"github.com/ahmetozer/sandal/pkg/lib/inotify"
@@ -33,12 +35,16 @@ func (d DaemonConfig) loadByEvent() {
 		// parse name from file if known event
 		switch event.Event {
 		case inotify.Modified, inotify.FileCreate, inotify.MovedFrom, inotify.Delete, inotify.MovedTo:
-			fileName := strings.Split(filepath.Base(event.Path), ".")
-			if len(fileName) != 2 && event.Event != inotify.WatchStop {
+			// Strip the ".json" suffix instead of splitting on "." so names
+			// that contain dots (allowed by ValidateName) are handled. The
+			// old split-on-dot dropped every dotted-name state file, so the
+			// daemon never processed their Delete and resurrected them (L6).
+			name, ok := config.NameFromConfigFile(filepath.Base(event.Path))
+			if !ok {
 				slog.Warn("loadByEvent", slog.Any("error", "unknown name for state file"), slog.String("file", event.Path))
 				continue
 			}
-			contName = fileName[0]
+			contName = name
 		}
 
 		switch event.Event {
@@ -47,7 +53,10 @@ func (d DaemonConfig) loadByEvent() {
 		case inotify.Modified, inotify.FileCreate, inotify.MovedFrom:
 			c, err := controller.LoadFile(event.Path)
 			if err != nil {
-				slog.Warn("loadByEvent", slog.Any("error", "unknown name for state file"), slog.String("file", event.Path))
+				// Skip on load failure: a partial/concurrent write yields a nil
+				// config, and SetContainer(nil) would panic the daemon.
+				slog.Warn("loadByEvent", slog.Any("error", "load state file"), slog.String("file", event.Path), slog.Any("err", err))
+				continue
 			}
 			controller.SetContainer(c)
 		case inotify.Delete, inotify.MovedTo:
@@ -58,5 +67,80 @@ func (d DaemonConfig) loadByEvent() {
 		default:
 			slog.Info("loadByEvent", slog.Any("event", event.Event), slog.String("error", "unknown event"))
 		}
+	}
+}
+
+// superviseDiskEvents runs loadByEvent and restarts it if the inotify watcher
+// dies (read/parse error, queue overflow that propagated, WatchStop). The
+// watcher is the only event-driven path that syncs in-memory state with disk;
+// if it died permanently, removals would be missed forever and startup
+// containers resurrected (audit L8). On every restart it runs a full
+// disk-authoritative reconcile to recover anything missed while it was down.
+// It stops once the daemon is shutting down.
+func (d DaemonConfig) superviseDiskEvents() {
+	for !shuttingDown.Load() {
+		d.loadByEvent()
+		if shuttingDown.Load() {
+			return
+		}
+		slog.Warn("loadByEvent", slog.String("msg", "watcher exited; reconciling and restarting"))
+		reconcileState()
+		time.Sleep(time.Second) // backoff to avoid a tight restart loop
+	}
+}
+
+// reconcileState makes the daemon's in-memory container list converge to the
+// authoritative on-disk state, independent of inotify health:
+//   - DROP: an in-memory entry whose state file is gone was removed (the
+//     watcher missed the Delete, or a dotted name slipped through an older
+//     parser); dropping it stops the health-check from resurrecting it (L6/L8).
+//   - ADD: a state file with no in-memory entry is a create the watcher missed;
+//     load it so the container is tracked (and recoverable).
+//
+// SetContainer writes memory and disk together, so an entry can only be in
+// memory if its file was written — therefore "in memory but no file" reliably
+// means removed, with no lock check required.
+func reconcileState() {
+	mem, err := controller.Containers()
+	if err != nil {
+		slog.Warn("reconcile", slog.Any("error", err))
+		return
+	}
+
+	entries, err := os.ReadDir(env.BaseStateDir)
+	if err != nil {
+		slog.Warn("reconcile", slog.String("action", "readdir"), slog.Any("error", err))
+		return
+	}
+	onDisk := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if name, ok := config.NameFromConfigFile(e.Name()); ok {
+			onDisk[name] = true
+		}
+	}
+
+	inMem := make(map[string]bool, len(mem))
+	for _, c := range mem {
+		inMem[c.Name] = true
+		if !onDisk[c.Name] {
+			slog.Info("reconcile", slog.String("action", "drop"), slog.String("cont", c.Name), slog.String("reason", "state file removed"))
+			controller.DeleteContainer(c.Name)
+		}
+	}
+
+	for name := range onDisk {
+		if inMem[name] {
+			continue
+		}
+		c, lerr := controller.LoadFile(config.ConfigFileLoc(name))
+		if lerr != nil {
+			slog.Warn("reconcile", slog.String("action", "load"), slog.String("cont", name), slog.Any("error", lerr))
+			continue
+		}
+		slog.Info("reconcile", slog.String("action", "add"), slog.String("cont", name))
+		controller.SetContainer(c)
 	}
 }

--- a/pkg/daemon/health-check.go
+++ b/pkg/daemon/health-check.go
@@ -55,7 +55,7 @@ func daemonControlHealthCheck(daemonKillRequested chan bool, wg *sync.WaitGroup)
 					// will install a fresh session.
 					host.Forwards.Stop(cont.Name)
 					if cont.Startup {
-						go contRecover(cont)
+						dispatchRecovery(cont)
 					} else {
 						slog.Debug("daemon", slog.String("cont", cont.Name), slog.String("msg", "recovering bypassed"))
 					}
@@ -81,6 +81,43 @@ func daemonControlHealthCheck(daemonKillRequested chan bool, wg *sync.WaitGroup)
 		}
 	}
 
+}
+
+// recovering tracks containers with an in-flight contRecover, keyed by
+// name with the time the recovery was claimed. It serializes recovery per
+// container: without it the 3-second health-check tick stacks concurrent
+// restarts when a recovery outlasts one tick, and each host.Run grabs a
+// fresh loop device, leaking the previous run's immutable mount.
+var recovering sync.Map // map[string]time.Time
+
+// maxRecoveryDuration bounds how long an in-flight claim is honored. A
+// goroutine wedged in an uninterruptible syscall (e.g. a stalled squashfs
+// mount) never runs its deferred release, so without a deadline a single
+// hang would stop the container from ever recovering again. Past the
+// deadline the claim is treated as stale and a fresh attempt is allowed.
+const maxRecoveryDuration = 90 * time.Second
+
+// dispatchRecovery starts contRecover for cont unless a recovery is already
+// in flight and still within maxRecoveryDuration. Only the (single-threaded)
+// health-check loop calls this, so the Load/Store pair needs no extra
+// locking; recovery goroutines only ever CompareAndDelete their own claim.
+func dispatchRecovery(cont *config.Config) {
+	now := time.Now()
+	if v, busy := recovering.Load(cont.Name); busy {
+		if now.Sub(v.(time.Time)) < maxRecoveryDuration {
+			slog.Debug("daemon", slog.String("cont", cont.Name), slog.String("msg", "recovery in flight, skipping"))
+			return
+		}
+		slog.Error("daemon", slog.String("cont", cont.Name), slog.String("msg", "recovery exceeded deadline, forcing retry"), slog.String("age", now.Sub(v.(time.Time)).String()))
+	}
+	token := now
+	recovering.Store(cont.Name, token)
+	go func() {
+		// CompareAndDelete (not Delete) so a zombie goroutine that finally
+		// unblocks after the deadline can't clear a newer recovery's claim.
+		defer recovering.CompareAndDelete(cont.Name, token)
+		contRecover(cont)
+	}()
 }
 
 func contRecover(cont *config.Config) {

--- a/pkg/daemon/health-check.go
+++ b/pkg/daemon/health-check.go
@@ -95,6 +95,13 @@ var recovering sync.Map // map[string]time.Time
 // mount) never runs its deferred release, so without a deadline a single
 // hang would stop the container from ever recovering again. Past the
 // deadline the claim is treated as stale and a fresh attempt is allowed.
+//
+// 90s assumes a recovery completes quickly, which holds for local-image
+// (-lw squashfs/disk) containers. A container whose -lw is a registry ref
+// can pull for up to the image-pull timeout (10m, see resolveLowerSource in
+// pkg/container/host/rootfs.go); such a recovery may cross this deadline and
+// get a second attempt stacked on it. Raise this above the pull timeout if
+// registry-backed startup containers are used.
 const maxRecoveryDuration = 90 * time.Second
 
 // dispatchRecovery starts contRecover for cont unless a recovery is already
@@ -108,7 +115,7 @@ func dispatchRecovery(cont *config.Config) {
 			slog.Debug("daemon", slog.String("cont", cont.Name), slog.String("msg", "recovery in flight, skipping"))
 			return
 		}
-		slog.Error("daemon", slog.String("cont", cont.Name), slog.String("msg", "recovery exceeded deadline, forcing retry"), slog.String("age", now.Sub(v.(time.Time)).String()))
+		slog.Warn("daemon", slog.String("cont", cont.Name), slog.String("msg", "previous recovery exceeded deadline (likely wedged in a mount/network syscall); forcing a fresh attempt"), slog.String("age", now.Sub(v.(time.Time)).String()), slog.String("deadline", maxRecoveryDuration.String()))
 	}
 	token := now
 	recovering.Store(cont.Name, token)

--- a/pkg/daemon/health-check.go
+++ b/pkg/daemon/health-check.go
@@ -6,10 +6,12 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ahmetozer/sandal/pkg/container/config"
 	"github.com/ahmetozer/sandal/pkg/container/host"
+	"github.com/ahmetozer/sandal/pkg/container/namelock"
 	"github.com/ahmetozer/sandal/pkg/container/net/renumber"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
@@ -27,6 +29,11 @@ func daemonControlHealthCheck(daemonKillRequested chan bool, wg *sync.WaitGroup)
 		case <-daemonKillRequested:
 			return
 		case <-time.After(3 * time.Second):
+			// Disk-authoritative reconcile first, so the per-container checks
+			// below act on state that matches disk even if the inotify watcher
+			// missed events (audit L6/L8).
+			reconcileState()
+
 			conts, err := controller.Containers()
 			if err != nil {
 				slog.Warn("unable to get containers", "err", err.Error())
@@ -34,13 +41,11 @@ func daemonControlHealthCheck(daemonKillRequested chan bool, wg *sync.WaitGroup)
 			for c := range conts {
 				cont := (conts)[c]
 
-				// For VM containers, monitor HostPid (the KVM process);
-				// for regular containers, monitor ContPid.
-				checkPid := cont.ContPid
-				if cont.VM != "" {
-					checkPid = cont.HostPid
-				}
-				isRunning, err := crt.IsPidRunning(checkPid)
+				// Monitor HostPid for VMs (the KVM process), ContPid for
+				// regular containers, and verify the start-time so a recycled
+				// pid isn't mistaken for a still-running container.
+				checkPid, wantStart := cont.MonitorPidIdentity()
+				isRunning, err := crt.IsPidRunningAs(checkPid, wantStart)
 				if err != nil {
 					slog.Warn("unable to get container status", "cont", cont.Name, "err", err.Error())
 				}
@@ -68,14 +73,11 @@ func daemonControlHealthCheck(daemonKillRequested chan bool, wg *sync.WaitGroup)
 			// statuses and "killed"-status containers don't keep proxy
 			// entries pinned.
 			renumber.ReconcileProxyForRunning(conts, func(c *config.Config) bool {
-				pid := c.ContPid
-				if c.VM != "" {
-					pid = c.HostPid
-				}
+				pid, wantStart := c.MonitorPidIdentity()
 				if pid == 0 {
 					return false
 				}
-				alive, _ := crt.IsPidRunning(pid)
+				alive, _ := crt.IsPidRunningAs(pid, wantStart)
 				return alive
 			})
 		}
@@ -88,41 +90,45 @@ func daemonControlHealthCheck(daemonKillRequested chan bool, wg *sync.WaitGroup)
 // container: without it the 3-second health-check tick stacks concurrent
 // restarts when a recovery outlasts one tick, and each host.Run grabs a
 // fresh loop device, leaking the previous run's immutable mount.
-var recovering sync.Map // map[string]time.Time
+// recovering holds names with an in-flight recovery goroutine, so the 3-second
+// health-check tick doesn't stack duplicate goroutines for the same container
+// while a recovery is still running. Cross-process and cross-goroutine
+// exclusion (against CLI run/kill/rm and against another recovery) is enforced
+// by the per-name lifecycle lock that contRecover takes; this set only avoids
+// redundant local goroutines.
+var recovering sync.Map // map[string]struct{}
 
-// maxRecoveryDuration bounds how long an in-flight claim is honored. A
-// goroutine wedged in an uninterruptible syscall (e.g. a stalled squashfs
-// mount) never runs its deferred release, so without a deadline a single
-// hang would stop the container from ever recovering again. Past the
-// deadline the claim is treated as stale and a fresh attempt is allowed.
-//
-// 90s assumes a recovery completes quickly, which holds for local-image
-// (-lw squashfs/disk) containers. A container whose -lw is a registry ref
-// can pull for up to the image-pull timeout (10m, see resolveLowerSource in
-// pkg/container/host/rootfs.go); such a recovery may cross this deadline and
-// get a second attempt stacked on it. Raise this above the pull timeout if
-// registry-backed startup containers are used.
-const maxRecoveryDuration = 90 * time.Second
+// recoveryWG tracks in-flight recovery goroutines so the shutdown path can
+// drain them before tearing containers down — otherwise a recovery that is
+// mid-placement when the daemon exits orphans a freshly started child (L1).
+var recoveryWG sync.WaitGroup
 
-// dispatchRecovery starts contRecover for cont unless a recovery is already
-// in flight and still within maxRecoveryDuration. Only the (single-threaded)
-// health-check loop calls this, so the Load/Store pair needs no extra
-// locking; recovery goroutines only ever CompareAndDelete their own claim.
+// shuttingDown, once set by the shutdown path, makes dispatchRecovery refuse to
+// launch new recoveries while the daemon is winding down.
+var shuttingDown atomic.Bool
+
+// beginShutdown stops new recoveries and blocks until in-flight ones finish.
+// Called from the daemon shutdown path before containers are torn down.
+func beginShutdown() {
+	shuttingDown.Store(true)
+	recoveryWG.Wait()
+}
+
+// dispatchRecovery starts contRecover for cont unless a recovery is already in
+// flight for that name or the daemon is shutting down. Only the
+// (single-threaded) health-check loop calls this.
 func dispatchRecovery(cont *config.Config) {
-	now := time.Now()
-	if v, busy := recovering.Load(cont.Name); busy {
-		if now.Sub(v.(time.Time)) < maxRecoveryDuration {
-			slog.Debug("daemon", slog.String("cont", cont.Name), slog.String("msg", "recovery in flight, skipping"))
-			return
-		}
-		slog.Warn("daemon", slog.String("cont", cont.Name), slog.String("msg", "previous recovery exceeded deadline (likely wedged in a mount/network syscall); forcing a fresh attempt"), slog.String("age", now.Sub(v.(time.Time)).String()), slog.String("deadline", maxRecoveryDuration.String()))
+	if shuttingDown.Load() {
+		return
 	}
-	token := now
-	recovering.Store(cont.Name, token)
+	if _, busy := recovering.LoadOrStore(cont.Name, struct{}{}); busy {
+		slog.Debug("daemon", slog.String("cont", cont.Name), slog.String("msg", "recovery in flight, skipping"))
+		return
+	}
+	recoveryWG.Add(1)
 	go func() {
-		// CompareAndDelete (not Delete) so a zombie goroutine that finally
-		// unblocks after the deadline can't clear a newer recovery's claim.
-		defer recovering.CompareAndDelete(cont.Name, token)
+		defer recoveryWG.Done()
+		defer recovering.Delete(cont.Name)
 		contRecover(cont)
 	}()
 }
@@ -131,6 +137,24 @@ func contRecover(cont *config.Config) {
 	if cont.Status == "stop" {
 		return
 	}
+
+	// Take the cross-process per-name lifecycle lock so this recovery cannot run
+	// concurrently with a CLI run/kill/rm for the same name, nor with another
+	// recovery. This is held across the kill+placement and replaces the old
+	// wall-clock deadline that could stack a second recovery and double-start
+	// the container (audit L2). Non-blocking: if another actor owns the name,
+	// skip this round; the next tick retries once they release.
+	release, ok, lerr := namelock.TryAcquire(cont.Name)
+	if lerr != nil {
+		slog.Warn("daemon", slog.String("cont", cont.Name), slog.String("msg", "lifecycle lock error"), slog.Any("err", lerr))
+		return
+	}
+	if !ok {
+		slog.Debug("daemon", slog.String("cont", cont.Name), slog.String("msg", "name busy, deferring recovery to next tick"))
+		return
+	}
+	defer release() // idempotent; the VM/native paths may release earlier
+
 	slog.Debug("daemon", slog.Any("action", "killing old"), slog.String("cont", cont.Name), slog.Any("contpid", cont.ContPid), slog.Any("hostpid", cont.HostPid))
 
 	// Clean up stale resources (console sockets, mounts, cgroups) left
@@ -147,8 +171,8 @@ func contRecover(cont *config.Config) {
 	// "running" because it was never updated. Since the health check
 	// already confirmed the PID is dead, treat any non-"stop" status
 	// as recoverable.
-	isAlive, _ := crt.IsPidRunning(cont.ContPid)
-	if isAlive {
+	contPid, contStart := cont.MonitorPidIdentity()
+	if isAlive, _ := crt.IsPidRunningAs(contPid, contStart); isAlive {
 		slog.Debug("daemon", slog.Any("status", cont.Status), slog.String("cont", cont.Name), slog.String("msg", "process still alive, skipping recovery"))
 		return
 	}
@@ -163,9 +187,14 @@ func contRecover(cont *config.Config) {
 		return
 	}
 
-	// If the container is already running (started by another path),
-	// skip recovery to avoid duplicate instances.
-	if isRunning, _ := crt.IsPidRunning(latest.ContPid); isRunning {
+	// Re-check under the lock: the user may have stopped it (status "stop") or
+	// it may have been started by another path since detection.
+	if latest.Status == "stop" {
+		slog.Debug("daemon", slog.String("cont", cont.Name), slog.String("msg", "status stop, skipping recovery"))
+		return
+	}
+	latestPid, latestStart := latest.MonitorPidIdentity()
+	if isRunning, _ := crt.IsPidRunningAs(latestPid, latestStart); isRunning {
 		slog.Debug("daemon", slog.String("cont", cont.Name), slog.String("msg", "already running, skipping recovery"))
 		return
 	}
@@ -176,21 +205,21 @@ func contRecover(cont *config.Config) {
 	}
 
 	if latest.VM != "" {
-		// VM container: re-run the full sandal.Run() pipeline which goes
-		// through RunInKVM() again (re-pulls images, re-allocates network,
-		// re-builds initrd, boots KVM).
-		err = sandal.Run(latest.HostArgs[2:])
-		if err != nil {
+		// VM recovery re-runs the full sandal.Run() pipeline, which goes through
+		// RunInKVM() and takes the per-name lock ITSELF. Release ours first to
+		// avoid a self-deadlock (flock contends even within one process).
+		release()
+		if err = sandal.Run(latest.HostArgs[2:]); err != nil {
 			slog.Error("recover vm", slog.String("cont", latest.Name), slog.Any("error", err))
 		}
 		slog.Info("recover", slog.String("cont", latest.Name), slog.String("type", "vm"))
 		return
 	}
 
-	err = host.Run(latest)
-	if err != nil {
+	// Native recovery: pass release as onPlaced so the lifecycle lock drops as
+	// soon as the recovered child's pid is published.
+	if err = host.Run(latest, release); err != nil {
 		slog.Error("recover", slog.Any("error", err))
 	}
 	slog.Info("recover", slog.String("cont", latest.Name))
-
 }

--- a/pkg/daemon/signal-proxy.go
+++ b/pkg/daemon/signal-proxy.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/ahmetozer/sandal/pkg/container/host"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
+	"github.com/ahmetozer/sandal/pkg/sandal"
 )
 
 func signalProxy(daemonKillRequested chan<- bool, wg *sync.WaitGroup) {
@@ -23,10 +23,14 @@ func signalProxy(daemonKillRequested chan<- bool, wg *sync.WaitGroup) {
 		sig := <-done
 		conts, _ := controller.Containers()
 		for _, cont := range conts {
-			// oldContPid := cont.ContPid
-			isRunning, err := crt.IsPidRunning(cont.ContPid)
+			// Monitor HostPid for VMs, ContPid for native — same rule and
+			// identity check as the health-check.
+			pid, wantStart := cont.MonitorPidIdentity()
+			isRunning, err := crt.IsPidRunningAs(pid, wantStart)
 			if cont.Startup && isRunning && err == nil {
-				host.Kill(cont, int(sig.(syscall.Signal)), 0)
+				// sandal.Kill routes VM containers to killVMHost (HostPid);
+				// host.Kill alone targets ContPid and never reaps a VM (L7).
+				sandal.Kill(cont, int(sig.(syscall.Signal)), 0)
 			}
 		}
 		// syscall.Kill(os.Getpid(), sig.(syscall.Signal))

--- a/pkg/daemon/start.go
+++ b/pkg/daemon/start.go
@@ -13,9 +13,11 @@ import (
 	"github.com/ahmetozer/sandal/pkg/container/host"
 	"github.com/ahmetozer/sandal/pkg/container/net"
 	"github.com/ahmetozer/sandal/pkg/container/net/renumber"
+	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
 	"github.com/ahmetozer/sandal/pkg/env"
 	"github.com/ahmetozer/sandal/pkg/lib/modprobe"
+	"github.com/ahmetozer/sandal/pkg/sandal"
 )
 
 type DaemonConfig struct {
@@ -29,7 +31,7 @@ func (dc DaemonConfig) Start() error {
 
 	go func() {
 		if dc.DiskReloadInterval == 0 {
-			dc.loadByEvent()
+			dc.superviseDiskEvents()
 		}
 	}()
 
@@ -130,6 +132,12 @@ func (dc DaemonConfig) Start() error {
 	go daemonControlHealthCheck(daemonKillRequested, &wg)
 	wg.Wait()
 
+	// Stop launching new recoveries and wait for any in-flight recovery to
+	// finish before tearing down. Otherwise a recovery that is mid-placement
+	// when the daemon exits leaves a freshly started child untracked and
+	// orphaned, and the next daemon start spawns a duplicate (audit L1).
+	beginShutdown()
+
 	// Release port-forward listeners before tearing down containers so
 	// in-flight relays don't dial into netns that's about to disappear.
 	host.Forwards.StopAll()
@@ -140,6 +148,19 @@ func (dc DaemonConfig) Start() error {
 		slog.Error("unable to deprovision container during close process", "error", err.Error())
 	} else {
 		for _, cont := range conts {
+			// VM children are Setsid session leaders detached from the daemon's
+			// process group; host.DeRunContainer targets ContPid (the in-VM pid,
+			// invisible from the host), so reap daemon-managed (startup) VMs by
+			// their KVM HostPid directly (audit L7).
+			if cont.VM != "" {
+				if cont.Startup {
+					pid, wantStart := cont.MonitorPidIdentity()
+					if alive, _ := crt.IsPidRunningAs(pid, wantStart); alive {
+						sandal.Kill(cont, 9, 10)
+					}
+				}
+				continue
+			}
 			// Do not kill containers, which is executed before daemon
 			if cont.HostPid == DaemonPid {
 				host.DeRunContainer(cont)

--- a/pkg/daemon/zombie.go
+++ b/pkg/daemon/zombie.go
@@ -6,9 +6,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/ahmetozer/sandal/pkg/container/host"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/controller"
+	"github.com/ahmetozer/sandal/pkg/sandal"
 )
 
 // checkZombie sends SIGTERM then SIGKILL to any startup containers still
@@ -37,18 +37,21 @@ func checkZombie() {
 
 		alive := false
 		for _, cont := range conts {
-			isRunning, err := crt.IsPidRunning(cont.ContPid)
+			pid, wantStart := cont.MonitorPidIdentity()
+			isRunning, err := crt.IsPidRunningAs(pid, wantStart)
 			if !cont.Startup || !isRunning || err != nil {
 				continue
 			}
 			alive = true
 
+			// sandal.Kill routes VMs to killVMHost(HostPid); host.Kill alone
+			// targets ContPid and never reaps the KVM process (audit L7).
 			if !termSent {
-				slog.Info("checkZombie", slog.String("action", "SIGTERM"), slog.String("cont", cont.Name), slog.Int("pid", cont.ContPid))
-				host.Kill(cont, 15, 0)
+				slog.Info("checkZombie", slog.String("action", "SIGTERM"), slog.String("cont", cont.Name), slog.Int("pid", pid))
+				sandal.Kill(cont, 15, 0)
 			} else if time.Now().After(graceExpiry) {
-				slog.Warn("checkZombie", slog.String("action", "SIGKILL"), slog.String("cont", cont.Name), slog.Int("pid", cont.ContPid))
-				host.Kill(cont, 9, 0)
+				slog.Warn("checkZombie", slog.String("action", "SIGKILL"), slog.String("cont", cont.Name), slog.Int("pid", pid))
+				sandal.Kill(cont, 9, 0)
 			}
 		}
 

--- a/pkg/lib/flock/flock.go
+++ b/pkg/lib/flock/flock.go
@@ -1,0 +1,58 @@
+//go:build linux || darwin
+
+// Package flock is a thin advisory whole-file lock (flock(2)) wrapper. The lock
+// is associated with the open file description, so it is released when the file
+// is closed or the process dies — there are no stale locks to clean up. flock
+// is cross-process: independent processes that lock the same path are mutually
+// excluded, which is what the per-name container lifecycle lock relies on.
+package flock
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Lock holds an flock on an open file. Not safe for concurrent use from
+// multiple goroutines; callers serialize their own access.
+type Lock struct {
+	f *os.File
+}
+
+// Open creates/opens path and returns an unlocked Lock. Call Lock or TryLock to
+// acquire, then Unlock to release (which also closes the file).
+func Open(path string) (*Lock, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	return &Lock{f: f}, nil
+}
+
+// Lock blocks until the exclusive lock is held.
+func (l *Lock) Lock() error {
+	return unix.Flock(int(l.f.Fd()), unix.LOCK_EX)
+}
+
+// TryLock attempts to take the exclusive lock without blocking. ok is false if
+// another holder owns it.
+func (l *Lock) TryLock() (ok bool, err error) {
+	err = unix.Flock(int(l.f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if err == unix.EWOULDBLOCK {
+		return false, nil
+	}
+	return false, err
+}
+
+// Unlock releases the lock and closes the underlying file.
+func (l *Lock) Unlock() error {
+	unlockErr := unix.Flock(int(l.f.Fd()), unix.LOCK_UN)
+	closeErr := l.f.Close()
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}

--- a/pkg/lib/flock/flock_test.go
+++ b/pkg/lib/flock/flock_test.go
@@ -1,0 +1,41 @@
+//go:build linux || darwin
+
+package flock
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// flock is per open-file-description: two independent opens of the same path
+// (even in the same process) contend. This guards the property the per-name
+// lifecycle lock relies on for cross-process mutual exclusion.
+func TestTryLockContended(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.lock")
+
+	a, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open a: %v", err)
+	}
+	if err := a.Lock(); err != nil {
+		t.Fatalf("a.Lock: %v", err)
+	}
+
+	b, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open b: %v", err)
+	}
+	if ok, err := b.TryLock(); err != nil || ok {
+		t.Fatalf("b.TryLock while a holds = (%v,%v), want (false,nil)", ok, err)
+	}
+
+	if err := a.Unlock(); err != nil {
+		t.Fatalf("a.Unlock: %v", err)
+	}
+	if ok, err := b.TryLock(); err != nil || !ok {
+		t.Fatalf("b.TryLock after a released = (%v,%v), want (true,nil)", ok, err)
+	}
+	if err := b.Unlock(); err != nil {
+		t.Fatalf("b.Unlock: %v", err)
+	}
+}

--- a/pkg/lib/inotify/events.go
+++ b/pkg/lib/inotify/events.go
@@ -64,11 +64,30 @@ func (w *Watcher) parseEvents(buf []byte) error {
 			name = string(bytes.TrimRight(nameBytes, "\x00"))
 		}
 
+		// IN_Q_OVERFLOW (delivered with Wd = -1) means the kernel dropped
+		// events because the queue filled. It must NOT be fatal: returning an
+		// error here propagates out of Watch() and kills the watcher for the
+		// daemon's lifetime, after which every removal is missed and startup
+		// containers get resurrected (audit L8). Skip it; the daemon's
+		// disk-authoritative reconcile recovers any state missed during the
+		// overflow burst.
+		if event.Mask&unix.IN_Q_OVERFLOW != 0 {
+			slog.Warn("parseEvents", slog.String("event", "IN_Q_OVERFLOW"),
+				slog.String("action", "queue overflowed; events dropped, will reconcile"))
+			offset += inotifyEventBaseSize + int(event.Len)
+			continue
+		}
+
 		w.mu.RLock()
 		dirPath, ok := w.watchMap[int(event.Wd)]
 		w.mu.RUnlock()
 		if !ok {
-			return fmt.Errorf("unknown watch descriptor: %d", event.Wd)
+			// Unknown watch descriptor (e.g. a watch already removed, or a
+			// stray sentinel). Skip rather than killing the whole watcher.
+			slog.Debug("parseEvents", slog.String("action", "skip unknown watch descriptor"),
+				slog.Int("wd", int(event.Wd)))
+			offset += inotifyEventBaseSize + int(event.Len)
+			continue
 		}
 
 		fullPath := filepath.Join(dirPath, name)

--- a/pkg/lib/inotify/events_test.go
+++ b/pkg/lib/inotify/events_test.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package inotify
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// encodeInotifyEvent builds a raw inotify_event record (header + null-padded
+// name) the way the kernel lays it out, so parseEvents can be exercised
+// without a live inotify fd.
+func encodeInotifyEvent(wd int32, mask, cookie uint32, name string) []byte {
+	var nameBytes []byte
+	if name != "" {
+		nameBytes = append([]byte(name), 0)
+		for len(nameBytes)%4 != 0 {
+			nameBytes = append(nameBytes, 0)
+		}
+	}
+	hdr := systemInotifyEvent{Wd: wd, Mask: mask, Cookie: cookie, Len: uint32(len(nameBytes))}
+	var b bytes.Buffer
+	_ = binary.Write(&b, binary.LittleEndian, hdr)
+	b.Write(nameBytes)
+	return b.Bytes()
+}
+
+// An IN_Q_OVERFLOW sentinel (wd = -1) must not be fatal: previously parseEvents
+// returned "unknown watch descriptor" for it, which propagated out of Watch()
+// and killed the watcher permanently (audit L8).
+func TestParseEventsOverflowNonFatal(t *testing.T) {
+	w := &Watcher{watchMap: map[int]string{}, Events: make(chan InotifyEvent, 8)}
+	buf := encodeInotifyEvent(-1, unix.IN_Q_OVERFLOW, 0, "")
+	if err := w.parseEvents(buf); err != nil {
+		t.Fatalf("IN_Q_OVERFLOW must be non-fatal, got error: %v", err)
+	}
+}
+
+// An event for a watch descriptor we don't know (e.g. a watch already removed)
+// must be skipped, not fatal.
+func TestParseEventsUnknownWdNonFatal(t *testing.T) {
+	w := &Watcher{watchMap: map[int]string{}, Events: make(chan InotifyEvent, 8)}
+	buf := encodeInotifyEvent(999, unix.IN_DELETE, 0, "x.json")
+	if err := w.parseEvents(buf); err != nil {
+		t.Fatalf("unknown watch descriptor must be non-fatal, got error: %v", err)
+	}
+}
+
+// A known wd must still be parsed and dispatched to Events.
+func TestParseEventsKnownWdDispatches(t *testing.T) {
+	w := &Watcher{watchMap: map[int]string{7: "/state"}, Events: make(chan InotifyEvent, 8)}
+	buf := encodeInotifyEvent(7, unix.IN_DELETE, 0, "web.app.json")
+	if err := w.parseEvents(buf); err != nil {
+		t.Fatalf("known wd parse error: %v", err)
+	}
+	select {
+	case ev := <-w.Events:
+		if ev.Event != Delete || ev.Path != "/state/web.app.json" {
+			t.Fatalf("unexpected event: %+v", ev)
+		}
+	default:
+		t.Fatal("expected a Delete event to be dispatched")
+	}
+}

--- a/pkg/lib/inotify/watcher.go
+++ b/pkg/lib/inotify/watcher.go
@@ -88,6 +88,12 @@ func (w *Watcher) Watch() error {
 		default:
 			n, err := unix.Read(w.fd, buf)
 			if err != nil {
+				// A signal-interrupted read is transient; retry instead of
+				// killing the watcher (the daemon installs signal handlers,
+				// so EINTR is reachable here).
+				if err == unix.EINTR {
+					continue
+				}
 				return fmt.Errorf("read error: %w", err)
 			}
 

--- a/pkg/lib/loopdev/backing.go
+++ b/pkg/lib/loopdev/backing.go
@@ -9,19 +9,64 @@ import (
 	"strings"
 )
 
-// BackingFile returns the path the loop device is currently backing, or
-// "" when the device is not attached (or sysfs is unreadable). The value
-// comes from /sys/block/loopN/loop/backing_file; the kernel appends
-// " (deleted)" when the backing inode has been unlinked, which is trimmed.
-func BackingFile(no int) string {
-	data, err := os.ReadFile("/sys/block/loop" + strconv.Itoa(no) + "/loop/backing_file")
+// sysfsField reads /sys/block/loop<no>/loop/<field>, trimmed. Returns "" on
+// error (device not attached, or sysfs unreadable). sysfs is keyed by the
+// kernel block-device name (loopN), independent of where the device node lives
+// (/dev vs a custom LOOP_DEVICE_PREFIX), so these reads work everywhere.
+func sysfsField(no int, field string) string {
+	data, err := os.ReadFile("/sys/block/loop" + strconv.Itoa(no) + "/loop/" + field)
 	if err != nil {
 		return ""
 	}
-	s := strings.TrimSpace(string(data))
-	s = strings.TrimSuffix(s, " (deleted)")
-	if s == "" {
-		return ""
+	return strings.TrimSpace(string(data))
+}
+
+// parseBackingFile cleans a /sys/.../backing_file value and reports whether the
+// kernel appended " (deleted)" (the backing inode was unlinked since attach).
+func parseBackingFile(raw string) (path string, deleted bool) {
+	s := strings.TrimSpace(raw)
+	if base, ok := strings.CutSuffix(s, " (deleted)"); ok {
+		base = strings.TrimSpace(base)
+		if base == "" {
+			return "", true
+		}
+		return filepath.Clean(base), true
 	}
-	return filepath.Clean(s)
+	if s == "" {
+		return "", false
+	}
+	return filepath.Clean(s), false
+}
+
+// BackingFile returns the path the loop device is currently backing, or "" when
+// the device is not attached. The kernel's " (deleted)" suffix is trimmed.
+func BackingFile(no int) string {
+	path, _ := parseBackingFile(sysfsField(no, "backing_file"))
+	return path
+}
+
+// BackingRaw returns the cleaned backing path AND whether the kernel marked it
+// "(deleted)". The reuse lookup uses deleted=true to refuse a stale mount.
+func BackingRaw(no int) (path string, deleted bool) {
+	return parseBackingFile(sysfsField(no, "backing_file"))
+}
+
+// Offset returns the loop device's backing-file offset (0 for whole-file
+// images, the partition start byte for partitioned images).
+func Offset(no int) uint64 {
+	v, _ := strconv.ParseUint(sysfsField(no, "offset"), 10, 64)
+	return v
+}
+
+// SizeLimit returns the loop device's size limit (0 = to end of file).
+func SizeLimit(no int) uint64 {
+	v, _ := strconv.ParseUint(sysfsField(no, "sizelimit"), 10, 64)
+	return v
+}
+
+// DevicePath returns the device node path for loop number no, honoring
+// LOOP_DEVICE_PREFIX. Used to reconstruct a Config when reusing an existing
+// loop discovered by number.
+func DevicePath(no int) string {
+	return LOOP_DEVICE_PREFIX + strconv.Itoa(no)
 }

--- a/pkg/lib/loopdev/backing.go
+++ b/pkg/lib/loopdev/backing.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package loopdev
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// BackingFile returns the path the loop device is currently backing, or
+// "" when the device is not attached (or sysfs is unreadable). The value
+// comes from /sys/block/loopN/loop/backing_file; the kernel appends
+// " (deleted)" when the backing inode has been unlinked, which is trimmed.
+func BackingFile(no int) string {
+	data, err := os.ReadFile("/sys/block/loop" + strconv.Itoa(no) + "/loop/backing_file")
+	if err != nil {
+		return ""
+	}
+	s := strings.TrimSpace(string(data))
+	s = strings.TrimSuffix(s, " (deleted)")
+	if s == "" {
+		return ""
+	}
+	return filepath.Clean(s)
+}

--- a/pkg/lib/loopdev/backing_test.go
+++ b/pkg/lib/loopdev/backing_test.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package loopdev
+
+import "testing"
+
+// parseBackingFile must clean the path and report whether the kernel marked the
+// backing file "(deleted)" (i.e. it was replaced/unlinked since attach), which
+// the reuse lookup uses to refuse reusing a stale mount.
+func TestParseBackingFile(t *testing.T) {
+	cases := []struct {
+		raw         string
+		wantPath    string
+		wantDeleted bool
+	}{
+		{"/media/mmcblk0p1/sandal/image/klipper.sq", "/media/mmcblk0p1/sandal/image/klipper.sq", false},
+		{"/img/klipper.sq (deleted)", "/img/klipper.sq", true},
+		{"/img/./a/../klipper.sq", "/img/klipper.sq", false},
+		{"  /img/x.sq  ", "/img/x.sq", false},
+		{"", "", false},
+		{"   ", "", false},
+	}
+	for _, tc := range cases {
+		path, deleted := parseBackingFile(tc.raw)
+		if path != tc.wantPath || deleted != tc.wantDeleted {
+			t.Errorf("parseBackingFile(%q) = (%q,%v), want (%q,%v)", tc.raw, path, deleted, tc.wantPath, tc.wantDeleted)
+		}
+	}
+}

--- a/pkg/sandal/kill.go
+++ b/pkg/sandal/kill.go
@@ -57,7 +57,9 @@ func killVMHost(c *config.Config, timeout int) error {
 		if running, _ := crt.IsPidRunning(pid); !running {
 			c.Status = "killed"
 			c.HostPid = 0
+			c.HostPidStart = 0
 			c.ContPid = 0
+			c.ContPidStart = 0
 			host.CleanupResources(c)
 			controller.SetContainer(c)
 			return nil

--- a/pkg/sandal/vm_linux.go
+++ b/pkg/sandal/vm_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ahmetozer/sandal/pkg/container/config"
 	"github.com/ahmetozer/sandal/pkg/container/console"
 	"github.com/ahmetozer/sandal/pkg/container/forward"
+	"github.com/ahmetozer/sandal/pkg/container/namelock"
 	sandalnet "github.com/ahmetozer/sandal/pkg/container/net"
 	crt "github.com/ahmetozer/sandal/pkg/container/runtime"
 	"github.com/ahmetozer/sandal/pkg/container/resources"
@@ -41,6 +42,18 @@ import (
 // guest inside SANDAL_VM_ARGS so the in-guest container init can apply the
 // same configuration to the matching ethN inside the VM.
 func RunInKVM(c *config.Config, netFlags []string) error {
+	// Serialize VM placement per name across processes (CLI ↔ daemon recovery)
+	// so two actors can't both pass the running-check and double-boot the VM,
+	// leaving one KVM child detached (audit L2/L3). For the daemon recovery /
+	// background path forkVMProcess publishes HostPid and returns, so the lock
+	// is held only across placement; a foreground `sandal run -vm` holds it for
+	// the VM's lifetime — the same scope as a foreground native run.
+	release, err := namelock.Acquire(c.Name, namelock.DefaultTimeout)
+	if err != nil {
+		return fmt.Errorf("acquire lifecycle lock for %q: %w", c.Name, err)
+	}
+	defer release()
+
 	if running, _ := crt.IsContainerRunning(c.Name); running {
 		return fmt.Errorf("container %s is already running", c.Name)
 	}
@@ -252,6 +265,7 @@ func RunInKVM(c *config.Config, netFlags []string) error {
 
 	// Foreground mode: register and boot directly in this process
 	c.HostPid = os.Getpid()
+	c.HostPidStart, _ = crt.ProcessStartTime(c.HostPid)
 	c.VM = "kvm"
 	c.Status = "running"
 	if err := controller.SetContainer(c); err != nil {
@@ -263,9 +277,11 @@ func RunInKVM(c *config.Config, netFlags []string) error {
 		}
 	}()
 
-	// Start host-side socket relay for vsock
+	// Start host-side socket relay for vsock; stop it when the VM exits so the
+	// vsock ports are released (audit L9).
 	if len(socketMounts) > 0 {
-		go StartHostSocketRelay(socketMounts)
+		stopRelay := StartHostSocketRelay(socketMounts)
+		defer stopRelay()
 	}
 
 	err = kvm.BootWithForwards(vmName, cfg, nil, nil, c.Ports)
@@ -302,20 +318,26 @@ func forkVMProcess(c *config.Config, vmName string, cfg vmconfig.VMConfig, socke
 	}
 
 	c.HostPid = cmd.Process.Pid
+	c.HostPidStart, _ = crt.ProcessStartTime(c.HostPid)
 	c.VM = "kvm"
 	c.Status = "running"
 	if err := controller.SetContainer(c); err != nil {
 		slog.Warn("runInKVM", slog.String("action", "register container"), slog.Any("error", err))
 	}
 
-	// Start host-side socket relay for vsock
+	// Start host-side socket relay for vsock; the wait goroutine below stops it
+	// when the VM child exits so a recovered VM can rebind the ports (audit L9).
+	var stopRelay func()
 	if len(socketMounts) > 0 {
-		go StartHostSocketRelay(socketMounts)
+		stopRelay = StartHostSocketRelay(socketMounts)
 	}
 
 	// Wait for child to exit and update status
 	go func() {
 		waitErr := cmd.Wait()
+		if stopRelay != nil {
+			stopRelay()
+		}
 		if consoleCleanup != nil {
 			consoleCleanup()
 		}
@@ -335,57 +357,83 @@ func forkVMProcess(c *config.Config, vmName string, cfg vmconfig.VMConfig, socke
 	return nil
 }
 
-// StartHostSocketRelay starts a vsock listener for each socket mount.
-func StartHostSocketRelay(sockets []SocketMount) {
+// StartHostSocketRelay starts a vsock listener for each socket mount and
+// returns a stop func that closes every listener fd. Closing a listener makes
+// its blocked Accept return, so the accept goroutine exits — no leaked
+// listener/goroutine. The caller MUST invoke stop when the VM exits, otherwise
+// the deterministic ports (5000+i) stay bound and a recovered/restarted VM with
+// the same socket mounts fails to rebind (EADDRINUSE) and its relays silently
+// never come up (audit L9).
+func StartHostSocketRelay(sockets []SocketMount) func() {
+	fds := make([]int, 0, len(sockets))
 	for i, sm := range sockets {
 		port := uint32(5000 + i)
-		go hostRelaySocket(sm.HostPath, port)
+		fd, err := listenVsock(port)
+		if err != nil {
+			slog.Warn("vsock relay listen failed", slog.Uint64("port", uint64(port)), slog.Any("err", err))
+			continue
+		}
+		fds = append(fds, fd)
+		go acceptRelayLoop(fd, sm.HostPath, port)
+	}
+	return func() {
+		for _, fd := range fds {
+			unix.Close(fd)
+		}
 	}
 }
 
-// hostRelaySocket listens on AF_VSOCK at the given port and for each accepted
-// connection, dials the host Unix socket and performs bidirectional relay.
-func hostRelaySocket(hostPath string, port uint32) {
+// listenVsock binds and listens an AF_VSOCK stream socket on port, returning the
+// listening fd. The fd is closed by the caller's stop func to tear the relay down.
+func listenVsock(port uint32) (int, error) {
 	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
 	if err != nil {
-		slog.Warn("vsock socket failed", slog.Any("err", err))
-		return
+		return -1, fmt.Errorf("vsock socket: %w", err)
 	}
 	if err := unix.Bind(fd, &unix.SockaddrVM{CID: unix.VMADDR_CID_ANY, Port: port}); err != nil {
 		unix.Close(fd)
-		slog.Warn("vsock bind failed", slog.Uint64("port", uint64(port)), slog.Any("err", err))
-		return
+		return -1, fmt.Errorf("vsock bind: %w", err)
 	}
 	if err := unix.Listen(fd, 8); err != nil {
 		unix.Close(fd)
-		slog.Warn("vsock listen failed", slog.Uint64("port", uint64(port)), slog.Any("err", err))
-		return
+		return -1, fmt.Errorf("vsock listen: %w", err)
 	}
+	return fd, nil
+}
 
+// acceptRelayLoop accepts vsock connections until fd is closed (Accept then
+// errors), relaying each to the host Unix socket.
+func acceptRelayLoop(fd int, hostPath string, port uint32) {
 	for {
 		nfd, _, err := unix.Accept(fd)
 		if err != nil {
-			slog.Warn("vsock accept failed", slog.Uint64("port", uint64(port)), slog.Any("err", err))
+			// fd was closed by the relay's stop func, or a transient accept
+			// error — either way this listener is finished.
+			slog.Debug("vsock accept loop exit", slog.Uint64("port", uint64(port)), slog.Any("err", err))
 			return
 		}
-		go func(clientFD int) {
-			vsockFile := os.NewFile(uintptr(clientFD), fmt.Sprintf("vsock-client:%d", port))
-			defer vsockFile.Close()
-
-			hostConn, err := net.Dial("unix", hostPath)
-			if err != nil {
-				slog.Warn("host socket dial failed", slog.String("path", hostPath), slog.Any("err", err))
-				return
-			}
-			defer hostConn.Close()
-
-			done := make(chan struct{})
-			go func() {
-				io.Copy(hostConn, vsockFile)
-				done <- struct{}{}
-			}()
-			io.Copy(vsockFile, hostConn)
-			<-done
-		}(nfd)
+		go relayConn(nfd, hostPath, port)
 	}
+}
+
+// relayConn performs bidirectional relay between an accepted vsock connection
+// and the host Unix socket.
+func relayConn(clientFD int, hostPath string, port uint32) {
+	vsockFile := os.NewFile(uintptr(clientFD), fmt.Sprintf("vsock-client:%d", port))
+	defer vsockFile.Close()
+
+	hostConn, err := net.Dial("unix", hostPath)
+	if err != nil {
+		slog.Warn("host socket dial failed", slog.String("path", hostPath), slog.Any("err", err))
+		return
+	}
+	defer hostConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		io.Copy(hostConn, vsockFile)
+		done <- struct{}{}
+	}()
+	io.Copy(vsockFile, hostConn)
+	<-done
 }


### PR DESCRIPTION
## Summary

A reliability hardening pass across the container lifecycle, daemon recovery, disk-image
handling, and networking. Several fixes address production incidents on real devices
(e.g. a failed-recovery storm that orphaned 16 loop mounts). The branch grew well beyond
its original namespace scope into a broad concurrency- and crash-safety effort.

## Lifecycle locking & identity
- Add `flock` and a per-container-name `namelock` (`pkg/lib/flock`, `pkg/container/namelock`)
  to serialize run / recover / kill / rm across the CLI, the daemon, and the daemon's own
  goroutines. flock is tied to the fd, so a crashed holder never wedges a name.
- Serialize lifecycle commands per name with identity-aware checks.
- Add PID start-time identity fields and `IsPidRunningAs` so we never act on a recycled PID;
  add `NameFromConfigFile`.
- Make `Kill` synchronous to stop a goroutine leak and fix `second=0` semantics.

## Daemon recovery & reconcile
- `dispatchRecovery` plus a per-name recovery lock and crun reaper.
- Disk-authoritative reconcile and VM child reaping; zombie/health-check hardening.

## Disk images & loop devices
- Reuse/share immutable mounts idempotently (match by backing file + offset + sizelimit,
  refuse `(deleted)` backings) and skip teardown of bases still referenced by a live overlay.
- Clean up leaked loop devices on every mount-failure path; skip live-sibling loops during
  immutable mount reclaim.

## Robustness fixes
- inotify: queue overflow and unknown-wd are non-fatal; retry on `EINTR`.
- overlayfs: guard the concurrent image-change map with a mutex + atomic take.
- controller: lock `containerList` and clone Configs to stop a concurrent-map race.
- x86 support fix.

## Tests
New/expanded unit + e2e coverage: namelock, flock, hostnet (+e2e), renumber, loopdev backing,
diskimage reuse, overlayfs image-changes, runtime status identity, net addr, inotify, config tools.
@